### PR TITLE
fix: persist backend timestamps immediately after post-session probe …

### DIFF
--- a/release/RELEASE_NOTES_v4.1.2.md
+++ b/release/RELEASE_NOTES_v4.1.2.md
@@ -1,0 +1,52 @@
+# CPAP AutoSync v4.1.2 — Retry Detection Fix
+
+> **OTA upgrades from v4.0, v4.1, or v4.1.1 are fully supported.** There are no partition-table or config.txt changes in this release.
+
+## What's Fixed in v4.1.2
+
+### 🔄 Retry Detection Now Works When a Backend Cannot Connect
+
+**This is a targeted bug fix release that corrects an edge case in the v4.1.1 upload retry fix.**
+
+v4.1.1 correctly stopped suppressing retries when a backend still had incomplete folders after a session. However, the retry decision relied on `totalFoldersCount`, which is only populated during the upload phase's folder scan.
+
+That created a failure mode when a backend never reached its folder scan at all — for example, when the NAS was temporarily unreachable and the SMB connection failed before Phase 2 could enumerate folders. In that case, `totalFoldersCount` could remain unset, causing the device to incorrectly believe there were no incomplete folders and suppress further retry attempts.
+
+**The fix:** incomplete-work detection now uses the work probe snapshot (`probeUniverse` vs `probeSynced`) instead of relying only on `totalFoldersCount`. The work probe runs before upload phases and after eligible sessions regardless of whether a backend can connect, so it accurately reflects whether each backend still has unsynced folders.
+
+This ensures the device correctly retries uploads when a destination is temporarily unavailable.
+
+---
+
+## Upgrade Instructions
+
+### Option 1 — OTA (Recommended)
+
+1. Open your device's dashboard at `http://cpap.local` (or its IP address).
+2. Go to the **OTA** tab.
+3. Either point the URL uploader at the `firmware-ota-upgrade-v4.1.2.bin` asset from the [Releases](https://github.com/ilyakruchinin/CPAP-AutoSync/releases) page, or download the file and upload it manually.
+4. The device will reboot into the new firmware. Configuration and upload state are preserved.
+
+### Option 2 — Full Flash via USB
+
+Only needed if you are upgrading from v3.6i or earlier, or if OTA fails.
+
+1. Download `firmware-ota-v4.1.2.bin` from the [Releases](https://github.com/ilyakruchinin/CPAP-AutoSync/releases) page.
+2. Open the [ESP Web Flasher](https://esp.huhn.me/) in Chrome/Edge.
+3. Connect your ESP32 via USB and select its serial port.
+4. Click **Erase** to clear the flash (this resets all settings).
+5. Set the flash address to `0x0` and select the downloaded `.bin` file.
+6. Click **Program** and wait for the flash to complete.
+7. The device will reboot into setup mode — follow the on-screen instructions to configure WiFi and upload settings.
+
+---
+
+## Known Limitations
+
+Unchanged from v4.0 — see `RELEASE_NOTES_v4.0.md` for details.
+
+---
+
+## Changelog Summary (since v4.1.1)
+
+- **Fix**: Incomplete-folder detection now uses the work probe snapshot (`probeUniverse` vs `probeSynced`) so retry suppression works correctly even when a backend fails to connect before its upload-phase folder scan can run.

--- a/release/RELEASE_NOTES_v4.1.3.md
+++ b/release/RELEASE_NOTES_v4.1.3.md
@@ -1,0 +1,67 @@
+# CPAP AutoSync v4.1.3 — Status Timestamp and Hostname Fixes
+
+> **OTA upgrades from v4.0, v4.1, v4.1.1, or v4.1.2 are fully supported.** There are no partition-table or config.txt changes in this release.
+
+## What's Fixed in v4.1.3
+
+### 📊 Per-Backend "Last upload" Now Reflects Actual No-Work Completion
+
+The dashboard's Upload Progress card shows separate `Last upload` values for SleepHQ Cloud and NAS (SMB). In some successful sessions, those timestamps could remain stale even though the post-session work probe showed all configured backends were fully synced.
+
+**The symptom:** the dashboard could show both backends as `9 / 9 ✓` and `Up to date`, but still report `Last upload: 5 days ago` or similar after an upload completed today.
+
+**The cause:** backend timestamps were stamped only in the older session-completion path and were not always persisted after being updated. The newer, authoritative work probe could prove that no work remained (`cloud=0 smb=0`, with `cloudSynced == universe` and `smbSynced == universe`), but that proof was not used to update each backend's saved `last_ts`.
+
+**The fix:** after the post-session work probe runs, each backend now updates and saves its own `Last upload` timestamp independently when that backend has no remaining work:
+
+- SleepHQ Cloud updates when Cloud has no work left and `cloudSynced == universe`.
+- NAS (SMB) updates when SMB has no work left and `smbSynced == universe`.
+- The session/day is marked complete only when all configured backends have no remaining work.
+
+This means Cloud and SMB timestamps now correctly reflect the last time each backend individually reached the fully-synced state.
+
+### 🌐 DHCP Hostname Is Applied Before Station Mode Starts
+
+Fixed a WiFi hostname timing issue contributed by m-kozlowski in PR #94.
+
+Previously, the firmware called `WiFi.mode(WIFI_STA)` before applying the configured hostname. In the Arduino WiFi layer, the hostname is applied during `WiFi.mode(WIFI_STA)` using the cached value from `NetworkManager::setHostname()`.
+
+Although `setHostname()` sets or resets the hostname, `WiFi.mode(WIFI_STA)` is asynchronous. That means DHCP DISCOVER could already have been sent using the cached default hostname before the configured hostname was applied.
+
+**The fix:** the configured hostname is now set before `WiFi.mode(WIFI_STA)`, so DHCP DISCOVER uses the configured hostname instead of a cached default.
+
+---
+
+## Upgrade Instructions
+
+### Option 1 — OTA (Recommended)
+
+1. Open your device's dashboard at `http://cpap.local` (or its IP address).
+2. Go to the **OTA** tab.
+3. Either point the URL uploader at the `firmware-ota-upgrade-v4.1.3.bin` asset from the [Releases](https://github.com/ilyakruchinin/CPAP-AutoSync/releases) page, or download the file and upload it manually.
+4. The device will reboot into the new firmware. Configuration and upload state are preserved.
+
+### Option 2 — Full Flash via USB
+
+Only needed if you are upgrading from v3.6i or earlier, or if OTA fails.
+
+1. Download `firmware-ota-v4.1.3.bin` from the [Releases](https://github.com/ilyakruchinin/CPAP-AutoSync/releases) page.
+2. Open the [ESP Web Flasher](https://esp.huhn.me/) in Chrome/Edge.
+3. Connect your ESP32 via USB and select its serial port.
+4. Click **Erase** to clear the flash (this resets all settings).
+5. Set the flash address to `0x0` and select the downloaded `.bin` file.
+6. Click **Program** and wait for the flash to complete.
+7. The device will reboot into setup mode — follow the on-screen instructions to configure WiFi and upload settings.
+
+---
+
+## Known Limitations
+
+Unchanged from v4.0 — see `RELEASE_NOTES_v4.0.md` for details.
+
+---
+
+## Changelog Summary (since v4.1.2)
+
+- **Fix**: Per-backend `Last upload` timestamps now update and persist after the post-session work probe proves that backend has no work left. Cloud and SMB are stamped independently.
+- **Fix**: Set configured hostname before `WiFi.mode(WIFI_STA)` so DHCP DISCOVER uses the configured hostname instead of the cached default.

--- a/src/FileUploader.cpp
+++ b/src/FileUploader.cpp
@@ -943,8 +943,14 @@ smb_phase_done:
         // this session.  Previously only the primary (cloud) got stamped,
         // which left the NAS (SMB) row showing a stale "Last upload: N days
         // ago" in the dashboard even after a successful phased session.
-        if (cloudStateManager) cloudStateManager->setLastUploadTimestamp((unsigned long)endNow);
-        if (smbStateManager)   smbStateManager->setLastUploadTimestamp((unsigned long)endNow);
+        if (cloudStateManager) {
+            cloudStateManager->setLastUploadTimestamp((unsigned long)endNow);
+            cloudStateManager->save(stateFs);
+        }
+        if (smbStateManager) {
+            smbStateManager->setLastUploadTimestamp((unsigned long)endNow);
+            smbStateManager->save(stateFs);
+        }
         if (scheduleManager)   scheduleManager->setLastUploadTimestamp((unsigned long)endNow);
         if (scheduleManager)   scheduleManager->markDayCompleted();
         LOG("[FileUploader] All folders complete — session done");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1247,12 +1247,46 @@ void uploadTaskFunction(void* pvParameters) {
     // shows 0 / 12 even though two folders were successfully uploaded during
     // the phase.  ERROR is still skipped: the state may be inconsistent and
     // a fresh probe on the next cycle will sort it out.
+    FileUploader::WorkProbeResult postWorkResult = {false, false, -1, -1, -1};
+    bool postProbeRan = false;
     if ((result == UploadResult::COMPLETE || result == UploadResult::NOTHING_TO_DO ||
          result == UploadResult::TIMEOUT)
         && params->sdManager->hasControl()) {
-        params->uploader->hasWorkToUpload(params->sdManager->getFS());
+        postWorkResult = params->uploader->hasWorkToUpload(params->sdManager->getFS());
+        postProbeRan = true;
         esp_task_wdt_reset();
         g_uploadHeartbeat = millis();
+    }
+
+    if (postProbeRan && result != UploadResult::ERROR) {
+        time_t completedAt = time(nullptr);
+        if (completedAt >= 1000000000) {
+            UploadStateManager* cloudSm = params->uploader->getCloudStateManager();
+            UploadStateManager* smbSm = params->uploader->getSmbStateManager();
+            bool cloudComplete = !cloudSm || (!postWorkResult.hasCloudWork &&
+                                             postWorkResult.universe >= 0 &&
+                                             postWorkResult.cloudSynced == postWorkResult.universe);
+            bool smbComplete = !smbSm || (!postWorkResult.hasSmbWork &&
+                                         postWorkResult.universe >= 0 &&
+                                         postWorkResult.smbSynced == postWorkResult.universe);
+
+            if (cloudSm && cloudComplete) {
+                cloudSm->setLastUploadTimestamp((unsigned long)completedAt);
+                cloudSm->save(LittleFS);
+            }
+            if (smbSm && smbComplete) {
+                smbSm->setLastUploadTimestamp((unsigned long)completedAt);
+                smbSm->save(LittleFS);
+            }
+            if (cloudComplete && smbComplete) {
+                ScheduleManager* schedule = params->uploader->getScheduleManager();
+                if (schedule) {
+                    schedule->setLastUploadTimestamp((unsigned long)completedAt);
+                    schedule->markDayCompleted();
+                }
+                result = UploadResult::COMPLETE;
+            }
+        }
     }
 
     // Step 5: Release SD card


### PR DESCRIPTION
…and mark session complete when all backends are synced