### PR TITLE
reduce SD card error window during WiFi connection failures

### DIFF
--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -249,7 +249,12 @@ bool WiFiManager::connectStation(const String& ssid, const String& password, con
 
     _lastDisconnectReason = 0;
     int attempts = 0;
-    while (WiFi.status() != WL_CONNECTED && attempts < 30) {
+    while (attempts < 30) {
+        wl_status_t status = WiFi.status();
+        if (status == WL_CONNECTED) break;
+        // Radio gave up - no point waiting the full timeout.
+        // The PMF retry path still runs if the disconnect reason warrants it.
+        if (status == WL_NO_SSID_AVAIL || status == WL_CONNECT_FAILED) break;
         delay(500);
         LOG_DEBUG(".");
         attempts++;
@@ -271,7 +276,10 @@ bool WiFiManager::connectStation(const String& ssid, const String& password, con
             esp_wifi_disconnect();
             esp_wifi_connect();
             attempts = 0;
-            while (WiFi.status() != WL_CONNECTED && attempts < 30) {
+            while (attempts < 30) {
+                wl_status_t status = WiFi.status();
+                if (status == WL_CONNECTED) break;
+                if (status == WL_NO_SSID_AVAIL || status == WL_CONNECT_FAILED) break;
                 delay(500);
                 LOG_DEBUG(".");
                 attempts++;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -755,9 +755,17 @@ void setup() {
             LOG_ERROR("Failed to connect to WiFi after 2 attempts.");
 
             // ── EMERGENCY BOOT ERROR DUMP ──
-            if (sdManager.takeControl()) {
-                Logger::getInstance().dumpToSD(sdManager.getFS(), "/uploader_error.txt", "WiFi connection failure");
-                sdManager.releaseControl();
+            // The WiFi attempts above ran a ~30s busy-wait that froze the main
+            // loop, so the PCNT idle counter is stale. Refresh it before gating.
+            trafficMonitor.update();
+            bool safeToDump = !g_pcntCapable || trafficMonitor.isIdleFor(2000);
+            if (safeToDump) {
+                if (sdManager.takeControl()) {
+                    Logger::getInstance().dumpToSD(sdManager.getFS(), "/uploader_error.txt", "WiFi connection failure");
+                    sdManager.releaseControl();
+                }
+            } else {
+                LOG_WARN("[Boot] CPAP bus active — skipping SD log dump to avoid mid-transaction MUX flip");
             }
 
             // Re-enable brownout detection if it was only relaxed for boot


### PR DESCRIPTION
Two small, workarounds for the SD-card-error-when-no-WiFi scenario reported in #84.
- Break the `connectStation()` busy-wait early when `WiFi.status()` reports a terminal state (`WL_NO_SSID_AVAIL`, `WL_CONNECT_FAILED`). The radio is already idle by then; spinning `delay(500)` for the rest of the 15s timeout just delays the FSM and starves `TrafficMonitor.update()` for no benefit.
- Gate the boot-time WiFi-failure SD log dump on PCNT-observed bus idle. On pcntCapable devices log dump is now deferred if the CPAP bus has been active in the last 2s.

Most likely the key factor is still WiFi RF current spikes during periodic reconnect attempts. This calls for a non-blocking reconnect refactor, exponential backoff, and a PCNT-aware activity gate that re-checks during the attempt.
But this overlaps heavily with multi-SSID / roaming / reconnect-hints rework I'm planning, so I am holding off for now.