### PR TITLE
feat: multi-SSID WiFi support with roaming, hint cache, and reconnect backoff

### DIFF
--- a/docs/config.txt.example.both
+++ b/docs/config.txt.example.both
@@ -1,8 +1,13 @@
 # CPAP AutoSync Configuration
 
 # WiFi Settings
+# WIFI_SSID is an alias for WIFI_SSID_1.  Up to 4 networks supported
+# (WIFI_SSID_1..4 / WIFI_PASSWORD_1..4).  Configure more than one to enable
+# automatic failover and RSSI-based roaming between them.
 WIFI_SSID = YourNetworkName
 WIFI_PASSWORD = YourNetworkPassword
+# WIFI_SSID_2 = SecondaryNetwork
+# WIFI_PASSWORD_2 = SecondaryPassword
 HOSTNAME = cpap
 # NTP_SERVER=pool.ntp.org
 

--- a/docs/config.txt.example.simple
+++ b/docs/config.txt.example.simple
@@ -2,6 +2,9 @@
 # This is the absolute minimum you need to get started!
 
 # ===== WiFi (Required) =====
+# WIFI_SSID is an alias for WIFI_SSID_1.  Up to 4 networks are supported
+# (WIFI_SSID_1..4 / WIFI_PASSWORD_1..4).  When multiple are configured, the
+# device automatically picks the strongest available one and roams between them.
 WIFI_SSID = YourWiFiName
 WIFI_PASSWORD = YourWiFiPassword
 

--- a/docs/config.txt.example.sleephq
+++ b/docs/config.txt.example.sleephq
@@ -1,8 +1,13 @@
 # CPAP AutoSync Configuration
 
 # WiFi Settings
+# WIFI_SSID is an alias for WIFI_SSID_1.  Up to 4 networks supported
+# (WIFI_SSID_1..4 / WIFI_PASSWORD_1..4).  Configure more than one to enable
+# automatic failover and RSSI-based roaming between them.
 WIFI_SSID = YourNetworkName
 WIFI_PASSWORD = YourNetworkPassword
+# WIFI_SSID_2 = SecondaryNetwork
+# WIFI_PASSWORD_2 = SecondaryPassword
 HOSTNAME = cpap
 # NTP_SERVER=pool.ntp.org
 

--- a/docs/config.txt.example.smb
+++ b/docs/config.txt.example.smb
@@ -1,8 +1,13 @@
 # CPAP AutoSync Configuration
 
 # WiFi Settings
+# WIFI_SSID is an alias for WIFI_SSID_1.  Up to 4 networks supported
+# (WIFI_SSID_1..4 / WIFI_PASSWORD_1..4).  Configure more than one to enable
+# automatic failover and RSSI-based roaming between them.
 WIFI_SSID = YourNetworkName
 WIFI_PASSWORD = YourNetworkPassword
+# WIFI_SSID_2 = SecondaryNetwork
+# WIFI_PASSWORD_2 = SecondaryPassword
 HOSTNAME = cpap
 # NTP_SERVER=pool.ntp.org
 

--- a/docs/dev/manual-configuration.md
+++ b/docs/dev/manual-configuration.md
@@ -21,12 +21,26 @@ If you prefer to keep your passwords as plaintext in `config.txt` (e.g., for eas
 
 **WIFI_SSID** (required)
 - Your WiFi network name
+- Alias for `WIFI_SSID_1` - the first slot in the multi-network table
 - Example: `WIFI_SSID = HomeNetwork`
 - Note: ESP32 only supports 2.4GHz WiFi (not 5GHz)
 
 **WIFI_PASSWORD** (required)
 - Your WiFi password
+- Alias for `WIFI_PASSWORD_1`
 - Example: `WIFI_PASSWORD = MySecurePassword123`
+
+**WIFI_SSID_1 .. WIFI_SSID_4 / WIFI_PASSWORD_1 .. WIFI_PASSWORD_4** (optional)
+- Up to 4 WiFi networks can be configured. The device picks the strongest available one at boot and roams between them as signal degrades.
+- Example:
+  ```
+  WIFI_SSID_1 = HomeNetwork
+  WIFI_PASSWORD_1 = primary-password
+  WIFI_SSID_2 = MobileHotspot
+  WIFI_PASSWORD_2 = backup-password
+  ```
+- `WIFI_SSID` / `WIFI_PASSWORD` (no suffix) are aliases for slot 1 - using either form is fine for single-network setups.
+- Each slot's password is stored in its own NVS key when `MASK_CREDENTIALS=true`. Slot 1 uses the legacy `wifi_pass` key for back-compat with existing flashed devices; slots 2–4 use `wifi_pass_2` / `wifi_pass_3` / `wifi_pass_4`.
 
 **HOSTNAME** (optional, default: "cpap")
 - Device hostname for local network discovery

--- a/docs/dev/specs/configuration-management.md
+++ b/docs/dev/specs/configuration-management.md
@@ -37,7 +37,8 @@ ENDPOINT = //192.168.1.100/cpap_backups
 ## Configuration Parameters
 
 ### Network Settings
-- `WIFI_SSID` / `WIFI_PASSWORD` - WiFi credentials
+- `WIFI_SSID` / `WIFI_PASSWORD` - WiFi credentials (alias for slot 1)
+- `WIFI_SSID_1..4` / `WIFI_PASSWORD_1..4` - up to 4 networks; roaming/failover is implicit when more than one is configured
 - `HOSTNAME` - mDNS hostname (default: "cpap")
 - `NTP_SERVER` - Custom NTP server (default: empty for DHCP Option 42 with pool.ntp.org fallback)
 

--- a/docs/dev/specs/wifi-network-management.md
+++ b/docs/dev/specs/wifi-network-management.md
@@ -31,8 +31,9 @@ bool recoverConnection() {
 ## Configuration
 
 ### Network Settings
-- **SSID**: From `WIFI_SSID` configuration
-- **Password**: From `WIFI_PASSWORD` configuration (securely stored)
+- **SSIDs**: Up to 4 configurable via `WIFI_SSID_1..4` (with `WIFI_SSID` as an alias for slot 1)
+- **Passwords**: `WIFI_PASSWORD_1..4` (with `WIFI_PASSWORD` as an alias for slot 1) - securely stored per slot in NVS when masking is enabled
+- **Roaming**: Implicit when more than one network is configured
 - **Hostname**: From `HOSTNAME` configuration (default: "cpap")
 - **Power management**: Configurable TX power and saving modes
 

--- a/include/Config.h
+++ b/include/Config.h
@@ -37,9 +37,17 @@ public:
     // Max line length for config file
     static const size_t MAX_LINE_LENGTH = 256;
 
+    // Maximum number of configured WiFi networks (WIFI_SSID_1 .. WIFI_SSID_N).
+    static constexpr int WIFI_MAX_NETWORKS = 4;
+
+    struct WiFiCredential {
+        String ssid;
+        String password;
+    };
+
 private:
-    String wifiSSID;
-    String wifiPassword;
+    WiFiCredential wifiNetworks[WIFI_MAX_NETWORKS];
+    int wifiNetworkCount;  // populated slots (0..WIFI_MAX_NETWORKS)
     String hostname;  // mDNS hostname (defaults to "cpap")
     String ntpServer; // Custom NTP server
     String schedule;
@@ -103,10 +111,16 @@ private:
     
     // Preferences constants
     static const char* PREFS_NAMESPACE;
-    static const char* PREFS_KEY_WIFI_PASS;
+    static const char* PREFS_KEY_WIFI_PASS;       // slot 0 (legacy key, preserved for back-compat)
+    static const char* PREFS_KEY_WIFI_PASS_2;     // slot 1
+    static const char* PREFS_KEY_WIFI_PASS_3;     // slot 2
+    static const char* PREFS_KEY_WIFI_PASS_4;     // slot 3
     static const char* PREFS_KEY_ENDPOINT_PASS;
     static const char* PREFS_KEY_CLOUD_SECRET;
     static const char* CENSORED_VALUE;
+
+    // Returns the NVS key for the WiFi password at slot idx, or nullptr if out of range.
+    static const char* prefsKeyForWifiSlot(int idx);
     
     // Preferences initialization and cleanup methods
     bool initPreferences();
@@ -137,8 +151,15 @@ public:
     bool loadFromString(const String& rawConfig);
     void overrideUploadMode(const String& mode);
     
+    // Slot-0 accessors (back-compat with single-network callers).
     const String& getWifiSSID() const;
     const String& getWifiPassword() const;
+
+    // Multi-slot accessors. idx in [0, getWifiNetworkCount()).
+    int getWifiNetworkCount() const;
+    const String& getWifiSSID(int idx) const;
+    const String& getWifiPassword(int idx) const;
+
     const String& getHostname() const;
     const String& getNtpServer() const;
     const String& getSchedule() const;

--- a/include/NetworkHints.h
+++ b/include/NetworkHints.h
@@ -1,0 +1,64 @@
+#ifndef NETWORK_HINTS_H
+#define NETWORK_HINTS_H
+
+#include <Arduino.h>
+
+// Per-AP connection hints - derived knowledge cached across reboots.
+// Keyed by (SSID, BSSID) so a mesh / multi-AP-per-SSID setup can have one
+// entry per physical AP.  Used by WiFiManager to short-circuit scans
+// (apply BSSID + channel directly) and to remember PMF/802.11w workarounds.
+//
+// Storage: NVS namespace "wifi_hints", single blob "blob" containing
+// [uint16 version][uint16 count][record x count]. 48 bytes per record,
+// capped at MAX_HINTS = 8 records, ~388 bytes total.
+//
+// last_used_secs is epoch seconds (time(nullptr)) Used later for LRU eviction
+// at cap and for stale-entry cleanup.
+
+struct SavedNetworkHint {
+    char     ssid[33];          // null-terminated, max 32 chars + null
+    uint8_t  bssid[6];          // BSSID (raw bytes)
+    uint8_t  channel;           // 1..14 for 2.4 GHz
+    uint8_t  pmf_disable;       // 1 = router needs PMF disabled (reason 208)
+    uint32_t last_used_secs;    // epoch seconds (time()) at last successful use
+};
+static_assert(sizeof(SavedNetworkHint) == 48, "SavedNetworkHint must pack to 48 bytes for stable on-disk layout");
+
+class NetworkHints {
+public:
+    static constexpr int      MAX_HINTS = 8;
+    static constexpr uint16_t BLOB_VERSION = 1;
+
+    NetworkHints();
+
+    bool begin();
+    bool save();
+    void clear();
+
+    // Lookup an exact (ssid, bssid) match. Returns nullptr if not found.
+    const SavedNetworkHint* find(const char* ssid, const uint8_t* bssid) const;
+
+    // Insert or update a hint. Refreshes last_used_secs to time(nullptr).
+    // If the array is full and the entry is new, the LRU entry is evicted.
+    // Returns false on argument error (null/empty ssid, null bssid).
+    bool upsert(const char* ssid, const uint8_t* bssid, uint8_t channel, bool pmf_disable);
+
+    // Drop entries with last_used_secs older than (nowSecs - maxAgeSecs).
+    // No-op if nowSecs <= maxAgeSecs (clock not synced).
+    int evictStale(uint32_t nowSecs, uint32_t maxAgeSecs);
+
+    int count() const { return _count; }
+    const SavedNetworkHint* at(int idx) const;
+
+private:
+    SavedNetworkHint _hints[MAX_HINTS];
+    int _count;
+
+    static const char* PREFS_NAMESPACE;
+    static const char* PREFS_KEY;
+
+    int findIndex(const char* ssid, const uint8_t* bssid) const;
+    void evictLRUSlot();
+};
+
+#endif  // NETWORK_HINTS_H

--- a/include/WiFiManager.h
+++ b/include/WiFiManager.h
@@ -75,12 +75,14 @@ private:
     static constexpr uint32_t CONNECT_PHASE_TIMEOUT_MS = 15000;
 
     static volatile uint8_t _lastDisconnectReason;  // Captured in event handler for retry logic
+    static volatile bool _hintRefreshPending; // flag consumed in pollConnect to refresh hint for current AP
     static void onWiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info);
 
     void enterPhase(ConnectPhase newPhase);
     void enterPmfRetry();
     void terminateConnect(ConnectPhase result);  // CONNECTED or FAILED
     void logConnectFailure();
+    void refreshHintForCurrentConnection();
 
     void prepareSingleCandidate(uint8_t configSlot);
     void kickScan();

--- a/include/WiFiManager.h
+++ b/include/WiFiManager.h
@@ -75,8 +75,18 @@ private:
     static constexpr uint32_t CONNECT_PHASE_TIMEOUT_MS = 15000;
 
     static volatile uint8_t _lastDisconnectReason;  // Captured in event handler for retry logic
-    static volatile bool _hintRefreshPending; // flag consumed in pollConnect to refresh hint for current AP
+    // STA_GOT_IP fires for every (re)association, including ones we did not
+    // initiate via beginConnect (e.g. NetworkRecovery::tryCoordinatedWifiCycle,
+    // or a supplicant-driven roam).  Pending flag is consumed in pollConnect
+    // to refresh the NetworkHints record for the current AP.
+    static volatile bool _hintRefreshPending;
+    // softAP client count used to gate background STA reconnect attempts
+    static volatile uint8_t _apClientCount;
     static void onWiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info);
+
+    // Stable-quiet teardown of the boot-fallback AP after STA recovers
+    uint32_t _apTeardownEligibleSinceMs;
+    static constexpr uint32_t AP_TEARDOWN_QUIET_MS = 120000;  // 2 minutes
 
     void enterPhase(ConnectPhase newPhase);
     void enterPmfRetry();
@@ -124,6 +134,14 @@ public:
     void startAP();
     void processDNS();
     bool isAPMode() const { return apMode; }
+
+    // softAP client tracking. While > 0, the caller (main loop) should skip
+    // background STA reconnect attempts so the user isn't kicked off mid-config.
+    uint8_t getApClientCount() const { return _apClientCount; }
+
+    // Returns true once the boot-fallback AP can be safely torn down: STA has been
+    // CONNECTED for AP_TEARDOWN_QUIET_MS, no AP clients connected during that window
+    bool shouldTearDownAP();
     
     bool isConnected() const;
     void disconnect();

--- a/include/WiFiManager.h
+++ b/include/WiFiManager.h
@@ -12,21 +12,57 @@ enum class WifiTxPower;
 enum class WifiPowerSaving;
 
 class WiFiManager {
+public:
+    // Connection state machine
+    enum class ConnectPhase {
+        IDLE,       // no attempt in progress
+        CONNECTING, // WiFi.begin() called with PMF enabled (default), awaiting result
+        PMF_RETRY,  // PMF disabled after reason-208 disconnect, awaiting result
+        CONNECTED,  // success, terminal
+        FAILED      // failure, terminal (timeout, no AP, auth fail...)
+    };
+
 private:
     bool connected;
     bool mdnsStarted;
     bool apMode;
     DNSServer dnsServer;
-    int8_t _pendingTxPower;   // Deferred TX power (dBm×4), applied in connectStation()
+    int8_t _pendingTxPower;   // Deferred TX power (dBm*4), applied during beginConnect()
     bool _hasPendingTxPower;
+
+    // beginConnect/pollConnect state. _pendingSsid/Password retained so PMF
+    // retry can re-issue the connection without the caller passing them again.
+    ConnectPhase _connectPhase;
+    uint32_t     _phaseStartMs;
+    String       _pendingSsid;
+    String       _pendingPassword;
+
+    static constexpr uint32_t CONNECT_PHASE_TIMEOUT_MS = 15000;
+
     static volatile uint8_t _lastDisconnectReason;  // Captured in event handler for retry logic
     static void onWiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info);
 
+    void enterPhase(ConnectPhase newPhase);
+    void enterPmfRetry();
+    void terminateConnect(ConnectPhase result);  // CONNECTED or FAILED
+    void logConnectFailure();
+
 public:
     WiFiManager();
-    
+
     void setupEventHandlers();
+
+    // Synchronous connect (boot path)
     bool connectStation(const String& ssid, const String& password, const String& hostname);
+
+    // Non-blocking connect API (loop reconnect path).
+    // beginConnect() starts an attempt; returns false on invalid args or if an
+    // attempt is already in progress. pollConnect() must be called from the
+    // main loop until isConnectInProgress() returns false.
+    bool beginConnect(const String& ssid, const String& password, const String& hostname);
+    void pollConnect();
+    bool isConnectInProgress() const;
+    ConnectPhase getConnectPhase() const { return _connectPhase; }
     void startAP();
     void processDNS();
     bool isAPMode() const { return apMode; }
@@ -34,7 +70,7 @@ public:
     bool isConnected() const;
     void disconnect();
     String getIPAddress() const;
-    int getSignalStrength() const;  // Returns RSSI in dBm
+    int getSignalStrength() const;    // Returns RSSI in dBm
     String getSignalQuality() const;  // Returns quality description
     
     // mDNS support
@@ -43,7 +79,7 @@ public:
     // Power management methods
     void setHighPerformanceMode();    // Disable power save for uploads
     void setPowerSaveMode();          // Enable power save for idle periods
-    void setMaxPowerSave();          // Maximum power savings
+    void setMaxPowerSave();           // Maximum power savings
     void applyTxPowerEarly(WifiTxPower txPower);  // Set TX power before WiFi.begin()
     void applyPowerSettings(WifiTxPower txPower, WifiPowerSaving powerSaving);  // Apply config settings
 };

--- a/include/WiFiManager.h
+++ b/include/WiFiManager.h
@@ -16,6 +16,7 @@ public:
     // Connection state machine
     enum class ConnectPhase {
         IDLE,       // no attempt in progress
+        SCANNING,   // async WiFi.scanNetworks() in progress (multi-SSID only)
         CONNECTING, // WiFi.begin() called with PMF enabled (default), awaiting result
         PMF_RETRY,  // PMF disabled after reason-208 disconnect, awaiting result
         CONNECTED,  // success, terminal
@@ -30,6 +31,19 @@ private:
     int8_t _pendingTxPower;   // Deferred TX power (dBm*4), applied during beginConnect()
     bool _hasPendingTxPower;
 
+    // One scan-result entry that matched a configured SSID.  Built during the
+    // SCANNING phase, sorted by RSSI desc, then tried in order.
+    struct Candidate {
+        uint8_t configSlot;   // index into Config.wifiNetworks[]
+        uint8_t bssid[6];     // BSSID from scan result (used as connect hint)
+        uint8_t channel;      // 1..14 (used as connect hint)
+        int8_t  rssi;         // dBm
+    };
+
+    static constexpr int     MAX_CANDIDATES        = 12;
+    static constexpr uint8_t CANDIDATE_MAX_RETRIES = 2;
+    static constexpr uint32_t SCAN_TIMEOUT_MS      = 12000;
+
     // beginConnect/pollConnect state. _pendingSsid/Password retained so PMF
     // retry can re-issue the connection without the caller passing them again.
     ConnectPhase _connectPhase;
@@ -37,6 +51,14 @@ private:
     String       _pendingSsid;
     String       _pendingPassword;
     uint8_t      _consecutiveFailures;
+
+    // Multi-SSID candidate iteration.
+    Candidate    _candidates[MAX_CANDIDATES];
+    uint8_t      _candidateCount;
+    uint8_t      _candidateIndex;
+    uint8_t      _candidateRetries;
+    const Config* _pendingConfig;
+    String       _pendingHostname;
 
     static constexpr uint32_t CONNECT_PHASE_TIMEOUT_MS = 15000;
 
@@ -48,19 +70,24 @@ private:
     void terminateConnect(ConnectPhase result);  // CONNECTED or FAILED
     void logConnectFailure();
 
+    void prepareSingleCandidate(uint8_t configSlot);
+    void kickScan();
+    void processScanResults();
+    bool startCurrentCandidate();
+    void onCurrentCandidateFailed();
+
 public:
     WiFiManager();
 
     void setupEventHandlers();
 
-    // Synchronous connect (boot path)
-    bool connectStation(const String& ssid, const String& password, const String& hostname);
+    // Multi-SSID connect. Reads up to WIFI_MAX_NETWORKS slots from Config.
+    // With 1 populated slot: direct WiFi.begin (no scan).
+    // With 2+: async scan first, ranks visible APs by RSSI, tries each
+    // connectStation() is the synchronous wrapper used at boot
+    bool connectStation(const Config& cfg);
+    bool beginConnect(const Config& cfg);
 
-    // Non-blocking connect API (loop reconnect path).
-    // beginConnect() starts an attempt; returns false on invalid args or if an
-    // attempt is already in progress. pollConnect() must be called from the
-    // main loop until isConnectInProgress() returns false.
-    bool beginConnect(const String& ssid, const String& password, const String& hostname);
     void pollConnect();
     bool isConnectInProgress() const;
     ConnectPhase getConnectPhase() const { return _connectPhase; }

--- a/include/WiFiManager.h
+++ b/include/WiFiManager.h
@@ -59,6 +59,7 @@ private:
     uint8_t      _candidateRetries;
     const Config* _pendingConfig;
     String       _pendingHostname;
+    bool         _pendingPmfDisable;
 
     static constexpr uint32_t CONNECT_PHASE_TIMEOUT_MS = 15000;
 

--- a/include/WiFiManager.h
+++ b/include/WiFiManager.h
@@ -36,6 +36,7 @@ private:
     uint32_t     _phaseStartMs;
     String       _pendingSsid;
     String       _pendingPassword;
+    uint8_t      _consecutiveFailures;
 
     static constexpr uint32_t CONNECT_PHASE_TIMEOUT_MS = 15000;
 
@@ -63,6 +64,12 @@ public:
     void pollConnect();
     bool isConnectInProgress() const;
     ConnectPhase getConnectPhase() const { return _connectPhase; }
+
+    // Recommended interval before the next reconnect attempt, in ms.
+    // Schedule (consecutive FAILED count -> interval): 0->30s, 1->60s,
+    // 2->2min, 3+->5min. Reset to 30s after a CONNECTED.
+    uint32_t getReconnectIntervalMs() const;
+    uint8_t  getConsecutiveFailures() const { return _consecutiveFailures; }
     void startAP();
     void processDNS();
     bool isAPMode() const { return apMode; }

--- a/include/WiFiManager.h
+++ b/include/WiFiManager.h
@@ -20,6 +20,7 @@ public:
         CONNECTING, // WiFi.begin() called with PMF enabled (default), awaiting result
         PMF_RETRY,  // PMF disabled after reason-208 disconnect, awaiting result
         CONNECTED,  // success, terminal
+        ROAM_SCAN,  // scan triggered by RSSI degradation while connected
         FAILED      // failure, terminal (timeout, no AP, auth fail...)
     };
 
@@ -61,6 +62,16 @@ private:
     String       _pendingHostname;
     bool         _pendingPmfDisable;
 
+    // Roaming state (active only when 2+ networks configured).
+    uint32_t     _lastRoamCheckMs;
+    uint8_t      _lowRssiCount;
+    bool         _roamSuspended;
+
+    static constexpr uint32_t ROAM_CHECK_INTERVAL_MS = 60000;
+    static constexpr int8_t   ROAM_RSSI_THRESHOLD    = -73;
+    static constexpr uint8_t  ROAM_LOW_RSSI_COUNT    = 3;
+    static constexpr int8_t   ROAM_HYSTERESIS_DB     = 8;
+
     static constexpr uint32_t CONNECT_PHASE_TIMEOUT_MS = 15000;
 
     static volatile uint8_t _lastDisconnectReason;  // Captured in event handler for retry logic
@@ -76,6 +87,10 @@ private:
     void processScanResults();
     bool startCurrentCandidate();
     void onCurrentCandidateFailed();
+
+    void roamingTick();
+    void kickRoamScan();
+    void processRoamScanResults();
 
 public:
     WiFiManager();
@@ -98,6 +113,12 @@ public:
     // 2->2min, 3+->5min. Reset to 30s after a CONNECTED.
     uint32_t getReconnectIntervalMs() const;
     uint8_t  getConsecutiveFailures() const { return _consecutiveFailures; }
+
+    // Roaming control. Suspend during upload sessions to avoid disconnecting
+    // mid-TLS or mid-SMB. Resume after the session ends.
+    void suspendRoaming();
+    void resumeRoaming();
+    bool isRoamingSuspended() const { return _roamSuspended; }
     void startAP();
     void processDNS();
     bool isAPMode() const { return apMode; }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -3,12 +3,26 @@
 
 // Define static constants for Preferences
 const char* Config::PREFS_NAMESPACE = "cpap_creds";
-const char* Config::PREFS_KEY_WIFI_PASS = "wifi_pass";
+const char* Config::PREFS_KEY_WIFI_PASS   = "wifi_pass";    // slot 0 (legacy key)
+const char* Config::PREFS_KEY_WIFI_PASS_2 = "wifi_pass_2";  // slot 1
+const char* Config::PREFS_KEY_WIFI_PASS_3 = "wifi_pass_3";  // slot 2
+const char* Config::PREFS_KEY_WIFI_PASS_4 = "wifi_pass_4";  // slot 3
 const char* Config::PREFS_KEY_ENDPOINT_PASS = "endpoint_pass";
 const char* Config::PREFS_KEY_CLOUD_SECRET = "cloud_secret";
 const char* Config::CENSORED_VALUE = "***STORED_IN_FLASH***";
 
-Config::Config() : 
+const char* Config::prefsKeyForWifiSlot(int idx) {
+    switch (idx) {
+        case 0: return PREFS_KEY_WIFI_PASS;
+        case 1: return PREFS_KEY_WIFI_PASS_2;
+        case 2: return PREFS_KEY_WIFI_PASS_3;
+        case 3: return PREFS_KEY_WIFI_PASS_4;
+        default: return nullptr;
+    }
+}
+
+Config::Config() :
+    wifiNetworkCount(0),
     gmtOffsetHours(0),  // Default: UTC
     ntpServer("pool.ntp.org"),
     saveLogs(false),  // Default: do not persist logs (debugging only)
@@ -178,15 +192,39 @@ void Config::parseLine(String& line) {
     setConfigValue(key, value);
 }
 
+// Returns the WiFi-network slot index for a key like WIFI_SSID, WIFI_SSID_1,
+// WIFI_PASSWORD_3, etc.  Returns -1 if the key is not a WiFi-network key.
+//   WIFI_SSID  / WIFI_PASSWORD     -> slot 0 (back-compat)
+//   WIFI_SSID_N / WIFI_PASSWORD_N  -> slot N-1 (1..WIFI_MAX_NETWORKS)
+static int parseWifiSlotKey(const String& key, bool& isSsid, bool& isPassword) {
+    isSsid = false;
+    isPassword = false;
+    if (key == "WIFI_SSID")       { isSsid = true;     return 0; }
+    if (key == "WIFI_PASSWORD")   { isPassword = true; return 0; }
+    if (key.startsWith("WIFI_SSID_")) {
+        int slot = key.substring(strlen("WIFI_SSID_")).toInt();
+        if (slot >= 1 && slot <= Config::WIFI_MAX_NETWORKS) { isSsid = true; return slot - 1; }
+    }
+    if (key.startsWith("WIFI_PASSWORD_")) {
+        int slot = key.substring(strlen("WIFI_PASSWORD_")).toInt();
+        if (slot >= 1 && slot <= Config::WIFI_MAX_NETWORKS) { isPassword = true; return slot - 1; }
+    }
+    return -1;
+}
+
 // Helper to set config values based on key (case-insensitive)
 void Config::setConfigValue(String key, String value) {
     key.toUpperCase(); // Convert key to uppercase for case-insensitive comparison
 
-    if (key == "WIFI_SSID") {
-        wifiSSID = value;
-    } else if (key == "WIFI_PASSWORD") {
-        wifiPassword = value;
-    } else if (key == "HOSTNAME") {
+    bool isSsid = false, isPassword = false;
+    int wifiSlot = parseWifiSlotKey(key, isSsid, isPassword);
+    if (wifiSlot >= 0) {
+        if (isSsid)     wifiNetworks[wifiSlot].ssid = value;
+        if (isPassword) wifiNetworks[wifiSlot].password = value;
+        return;
+    }
+
+    if (key == "HOSTNAME") {
         hostname = value.isEmpty() ? "cpap" : value;
     } else if (key == "NTP_SERVER") {
         ntpServer = value;
@@ -318,7 +356,8 @@ bool Config::censorConfigFile(fs::FS &sd) {
             key.trim();
             key.toUpperCase();
             
-            if (key == "WIFI_PASSWORD" || key == "ENDPOINT_PASSWORD" || key == "CLOUD_CLIENT_SECRET") {
+            bool isWifiPassword = (key == "WIFI_PASSWORD") || key.startsWith("WIFI_PASSWORD_");
+            if (isWifiPassword || key == "ENDPOINT_PASSWORD" || key == "CLOUD_CLIENT_SECRET") {
                 // It's a secret, reconstruct the line with censored value
                 String originalKey = line.substring(0, line.indexOf('=')); // Keep original casing/spacing
                 tempFile.println(originalKey + " = " + String(CENSORED_VALUE));
@@ -359,39 +398,51 @@ bool Config::migrateToSecureStorage(fs::FS &sd) {
     LOG("========================================");
     
     // Step 1: Validate that credentials are not empty
-    if (wifiPassword.isEmpty() && endpointPassword.isEmpty() && cloudClientSecret.isEmpty()) {
+    bool anyWifiPassword = false;
+    for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
+        if (!wifiNetworks[i].password.isEmpty()) { anyWifiPassword = true; break; }
+    }
+    if (!anyWifiPassword && endpointPassword.isEmpty() && cloudClientSecret.isEmpty()) {
         LOG_WARN("All credentials are empty, skipping migration");
         return false;
     }
-    
+
     // Step 2: Store credentials in Preferences
     bool success = true;
-    
-    if (!wifiPassword.isEmpty() && !isCensored(wifiPassword)) {
-        LOG_DEBUG("Storing WiFi password in Preferences...");
-        if (!storeCredential(PREFS_KEY_WIFI_PASS, wifiPassword)) success = false;
+
+    for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
+        const String& pw = wifiNetworks[i].password;
+        if (pw.isEmpty() || isCensored(pw)) continue;
+        const char* nvsKey = prefsKeyForWifiSlot(i);
+        if (!nvsKey) continue;
+        LOG_DEBUGF("Storing WiFi password slot %d in Preferences...", i + 1);
+        if (!storeCredential(nvsKey, pw)) success = false;
     }
-    
+
     if (!endpointPassword.isEmpty() && !isCensored(endpointPassword)) {
         LOG_DEBUG("Storing endpoint password in Preferences...");
         if (!storeCredential(PREFS_KEY_ENDPOINT_PASS, endpointPassword)) success = false;
     }
-    
+
     if (!cloudClientSecret.isEmpty() && !isCensored(cloudClientSecret)) {
         LOG_DEBUG("Storing cloud client secret in Preferences...");
         if (!storeCredential(PREFS_KEY_CLOUD_SECRET, cloudClientSecret)) success = false;
     }
-    
+
     if (!success) {
         LOG_ERROR("Failed to store some credentials");
         LOG("Migration aborted - keeping plain text credentials");
         return false;
     }
-    
+
     // Step 3: Verify credentials
     LOG_DEBUG("Verifying stored credentials...");
-    if (!wifiPassword.isEmpty() && !isCensored(wifiPassword)) {
-        if (loadCredential(PREFS_KEY_WIFI_PASS, "") != wifiPassword) success = false;
+    for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
+        const String& pw = wifiNetworks[i].password;
+        if (pw.isEmpty() || isCensored(pw)) continue;
+        const char* nvsKey = prefsKeyForWifiSlot(i);
+        if (!nvsKey) continue;
+        if (loadCredential(nvsKey, "") != pw) success = false;
     }
     if (!endpointPassword.isEmpty() && !isCensored(endpointPassword)) {
         if (loadCredential(PREFS_KEY_ENDPOINT_PASS, "") != endpointPassword) success = false;
@@ -438,9 +489,14 @@ bool Config::loadFromString(const String& rawConfig) {
     // Handle masked credentials: load from Preferences (NVS) if censored
     if (maskCredentials) {
         if (initPreferences()) {
-            if (isCensored(wifiPassword)) {
-                wifiPassword = loadCredential(PREFS_KEY_WIFI_PASS, "");
-                LOG("Loaded WiFi password from flash");
+            for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
+                if (isCensored(wifiNetworks[i].password)) {
+                    const char* nvsKey = prefsKeyForWifiSlot(i);
+                    if (nvsKey) {
+                        wifiNetworks[i].password = loadCredential(nvsKey, "");
+                        LOGF("Loaded WiFi password slot %d from flash", i + 1);
+                    }
+                }
             }
             if (isCensored(endpointPassword)) {
                 endpointPassword = loadCredential(PREFS_KEY_ENDPOINT_PASS, "");
@@ -466,7 +522,7 @@ bool Config::loadFromString(const String& rawConfig) {
     // Normalize and validate config values
     validateAndNormalize();
 
-    isValid = !wifiSSID.isEmpty();
+    isValid = (wifiNetworkCount > 0);
 
     if (isValid) {
         LOG("Config loaded successfully from raw string");
@@ -513,10 +569,12 @@ bool Config::loadFromSD(fs::FS &sd) {
         // This happens when a user upgrades firmware or disables masking after credentials
         // were already migrated to NVS. Log a loud error so the user knows to re-enter them.
         bool anyCensored = false;
-        if (isCensored(wifiPassword)) {
-            LOG_ERROR("WiFi password is '***STORED_IN_FLASH***' but MASK_CREDENTIALS is off.");
-            LOG_ERROR("NVS data may be lost after a full (non-OTA) flash. Please re-enter your WiFi password in config.txt.");
-            anyCensored = true;
+        for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
+            if (isCensored(wifiNetworks[i].password)) {
+                LOG_ERRORF("WIFI_PASSWORD_%d is '***STORED_IN_FLASH***' but MASK_CREDENTIALS is off.", i + 1);
+                LOG_ERROR("NVS data may be lost after a full (non-OTA) flash. Please re-enter your WiFi password in config.txt.");
+                anyCensored = true;
+            }
         }
         if (isCensored(endpointPassword)) {
             LOG_ERROR("Endpoint password is '***STORED_IN_FLASH***' but MASK_CREDENTIALS is off.");
@@ -548,16 +606,21 @@ bool Config::loadFromSD(fs::FS &sd) {
             maskCredentials = false;
             credentialsInFlash = false;
         } else {
-            // Check loaded credentials for censorship
-            bool wifiCensored = isCensored(wifiPassword);
+            // Check loaded credentials for censorship (per WiFi slot + endpoint + cloud)
+            bool anyWifiCensored = false;
+            for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
+                if (isCensored(wifiNetworks[i].password)) {
+                    anyWifiCensored = true;
+                    const char* nvsKey = prefsKeyForWifiSlot(i);
+                    if (nvsKey) {
+                        wifiNetworks[i].password = loadCredential(nvsKey, "");
+                        LOGF("Loaded WiFi password slot %d from flash", i + 1);
+                    }
+                }
+            }
             bool endpointCensored = isCensored(endpointPassword);
             bool cloudSecretCensored = isCensored(cloudClientSecret);
-            
-            // If censored, load from preferences
-            if (wifiCensored) {
-                wifiPassword = loadCredential(PREFS_KEY_WIFI_PASS, "");
-                LOG("Loaded WiFi password from flash");
-            }
+
             if (endpointCensored) {
                 endpointPassword = loadCredential(PREFS_KEY_ENDPOINT_PASS, "");
                 LOG("Loaded endpoint password from flash");
@@ -566,12 +629,15 @@ bool Config::loadFromSD(fs::FS &sd) {
                 cloudClientSecret = loadCredential(PREFS_KEY_CLOUD_SECRET, "");
                 LOG("Loaded cloud client secret from flash");
             }
-            
-            credentialsInFlash = (wifiCensored || endpointCensored || cloudSecretCensored);
-            
+
+            credentialsInFlash = (anyWifiCensored || endpointCensored || cloudSecretCensored);
+
             // Check for migration needed (plaintext credentials present in mask mode)
             bool needsMigration = false;
-            if (!wifiPassword.isEmpty() && !wifiCensored) needsMigration = true;
+            for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
+                const String& pw = wifiNetworks[i].password;
+                if (!pw.isEmpty() && !isCensored(pw)) { needsMigration = true; break; }
+            }
             if (!endpointPassword.isEmpty() && !endpointCensored) needsMigration = true;
             if (!cloudClientSecret.isEmpty() && !cloudSecretCensored) needsMigration = true;
             
@@ -585,15 +651,8 @@ bool Config::loadFromSD(fs::FS &sd) {
     }
     
     // Step 3: Validate configuration
-    
-    // Validate SSID length (WiFi standard limit is 32 characters)
-    if (wifiSSID.length() > 32) {
-        LOG_ERROR("SSID exceeds maximum length of 32 characters");
-        LOGF("SSID length: %d characters", wifiSSID.length());
-        LOG("Truncating SSID to 32 characters");
-        wifiSSID = wifiSSID.substring(0, 32);
-    }
-    
+    // (SSID-length truncation handled per-slot in validateAndNormalize() below.)
+
     // Compute cached endpoint type flags from the (possibly comma-separated) endpointType string
     {
         String upper = endpointType;
@@ -644,7 +703,7 @@ bool Config::loadFromSD(fs::FS &sd) {
     
     validateAndNormalize();
     
-    isValid = !wifiSSID.isEmpty() && hasValidEndpoint;
+    isValid = (wifiNetworkCount > 0) && hasValidEndpoint;
     
     if (isValid) {
         LOG("========================================");
@@ -666,8 +725,19 @@ bool Config::loadFromSD(fs::FS &sd) {
     return isValid;
 }
 
-const String& Config::getWifiSSID() const { return wifiSSID; }
-const String& Config::getWifiPassword() const { return wifiPassword; }
+const String& Config::getWifiSSID() const { return wifiNetworks[0].ssid; }
+const String& Config::getWifiPassword() const { return wifiNetworks[0].password; }
+int Config::getWifiNetworkCount() const { return wifiNetworkCount; }
+const String& Config::getWifiSSID(int idx) const {
+    static const String empty;
+    if (idx < 0 || idx >= WIFI_MAX_NETWORKS) return empty;
+    return wifiNetworks[idx].ssid;
+}
+const String& Config::getWifiPassword(int idx) const {
+    static const String empty;
+    if (idx < 0 || idx >= WIFI_MAX_NETWORKS) return empty;
+    return wifiNetworks[idx].password;
+}
 const String& Config::getHostname() const { return hostname; }
 const String& Config::getNtpServer() const { return ntpServer; }
 const String& Config::getSchedule() const { return schedule; }
@@ -746,6 +816,32 @@ bool Config::isSmartMode() const { return uploadMode.equalsIgnoreCase("smart") &
 bool Config::isSmartConfigInvalid() const { return smartConfigInvalid; }
 
 void Config::validateAndNormalize() {
+    // WiFi networks: truncate over-length SSIDs, then compact populated slots
+    // Empty SSIDs (gaps from e.g. only WIFI_SSID_3 being set) are pulled forward
+    // so wifiNetworks[0..wifiNetworkCount-1] is contiguous.  Roaming/failover is
+    // implicit when wifiNetworkCount > 1.
+    for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
+        if (wifiNetworks[i].ssid.length() > 32) {
+            LOG_WARNF("WIFI_SSID_%d exceeds 32 chars - truncating", i + 1);
+            wifiNetworks[i].ssid = wifiNetworks[i].ssid.substring(0, 32);
+        }
+    }
+    int dst = 0;
+    for (int src = 0; src < WIFI_MAX_NETWORKS; src++) {
+        if (!wifiNetworks[src].ssid.isEmpty()) {
+            if (dst != src) {
+                wifiNetworks[dst] = wifiNetworks[src];
+                wifiNetworks[src] = WiFiCredential{};
+            }
+            dst++;
+        }
+    }
+    // Clear any tail slots above the populated count
+    for (int i = dst; i < WIFI_MAX_NETWORKS; i++) {
+        wifiNetworks[i] = WiFiCredential{};
+    }
+    wifiNetworkCount = dst;
+
     // Validation of numeric ranges
     if (maxDays <= 0) { maxDays = 365; }
     else if (maxDays > 366) { maxDays = 366; }

--- a/src/NetworkHints.cpp
+++ b/src/NetworkHints.cpp
@@ -1,0 +1,179 @@
+#include "NetworkHints.h"
+#include "Logger.h"
+#include <Preferences.h>
+#include <time.h>
+#include <string.h>
+
+const char* NetworkHints::PREFS_NAMESPACE = "wifi_hints";
+const char* NetworkHints::PREFS_KEY       = "blob";
+
+// Blob layout:
+//   [uint16_t version][uint16_t count][SavedNetworkHint x count]
+
+NetworkHints::NetworkHints() : _count(0) {
+    memset(_hints, 0, sizeof(_hints));
+}
+
+bool NetworkHints::begin() {
+    _count = 0;
+
+    Preferences prefs;
+    if (!prefs.begin(PREFS_NAMESPACE, true /*read-only*/)) {
+        LOG_DEBUG("[Hints] NVS namespace empty - starting with no cached hints");
+        return false;
+    }
+
+    size_t blobSize = prefs.getBytesLength(PREFS_KEY);
+    if (blobSize < 4) {
+        prefs.end();
+        return false;
+    }
+
+    constexpr size_t maxBlob = 4 + MAX_HINTS * sizeof(SavedNetworkHint);
+    if (blobSize > maxBlob) {
+        LOG_WARNF("[Hints] NVS blob too large (%u bytes), discarding", (unsigned)blobSize);
+        prefs.end();
+        return false;
+    }
+
+    uint8_t buf[maxBlob];
+    size_t got = prefs.getBytes(PREFS_KEY, buf, blobSize);
+    prefs.end();
+
+    if (got != blobSize) return false;
+
+    uint16_t version = (uint16_t)buf[0] | ((uint16_t)buf[1] << 8);
+    uint16_t count   = (uint16_t)buf[2] | ((uint16_t)buf[3] << 8);
+
+    if (version != BLOB_VERSION) {
+        LOG_WARNF("[Hints] Blob version %u != expected %u - discarding", version, BLOB_VERSION);
+        return false;
+    }
+    if (count > MAX_HINTS) {
+        LOG_WARNF("[Hints] Blob count %u > MAX_HINTS %d - discarding", count, MAX_HINTS);
+        return false;
+    }
+    if (4 + (size_t)count * sizeof(SavedNetworkHint) != blobSize) {
+        LOG_WARN("[Hints] Blob size/count mismatch - discarding");
+        return false;
+    }
+
+    memcpy(_hints, buf + 4, (size_t)count * sizeof(SavedNetworkHint));
+    _count = count;
+
+    for (int i = 0; i < _count; i++) {
+        _hints[i].ssid[sizeof(_hints[i].ssid) - 1] = '\0';
+    }
+
+    LOG_INFOF("[Hints] Loaded %d network hint(s) from NVS", _count);
+    return true;
+}
+
+bool NetworkHints::save() {
+    Preferences prefs;
+    if (!prefs.begin(PREFS_NAMESPACE, false /*read-write*/)) {
+        LOG_ERROR("[Hints] Failed to open NVS for write");
+        return false;
+    }
+
+    constexpr size_t maxBlob = 4 + MAX_HINTS * sizeof(SavedNetworkHint);
+    uint8_t buf[maxBlob];
+    buf[0] = (uint8_t)(BLOB_VERSION & 0xFF);
+    buf[1] = (uint8_t)(BLOB_VERSION >> 8);
+    buf[2] = (uint8_t)(_count & 0xFF);
+    buf[3] = (uint8_t)((uint16_t)_count >> 8);
+
+    size_t recordsBytes = (size_t)_count * sizeof(SavedNetworkHint);
+    memcpy(buf + 4, _hints, recordsBytes);
+
+    size_t written = prefs.putBytes(PREFS_KEY, buf, 4 + recordsBytes);
+    prefs.end();
+
+    if (written != 4 + recordsBytes) {
+        LOG_ERRORF("[Hints] Short write: %u / %u bytes", (unsigned)written, (unsigned)(4 + recordsBytes));
+        return false;
+    }
+    LOG_DEBUGF("[Hints] Saved %d hint(s), %u bytes", _count, (unsigned)(4 + recordsBytes));
+    return true;
+}
+
+int NetworkHints::findIndex(const char* ssid, const uint8_t* bssid) const {
+    if (!ssid || !bssid) return -1;
+    for (int i = 0; i < _count; i++) {
+        if (memcmp(_hints[i].bssid, bssid, 6) != 0) continue;
+        if (strcmp(_hints[i].ssid, ssid) != 0) continue;
+        return i;
+    }
+    return -1;
+}
+
+const SavedNetworkHint* NetworkHints::find(const char* ssid, const uint8_t* bssid) const {
+    int idx = findIndex(ssid, bssid);
+    return (idx < 0) ? nullptr : &_hints[idx];
+}
+
+bool NetworkHints::upsert(const char* ssid, const uint8_t* bssid, uint8_t channel, bool pmf_disable) {
+    if (!ssid || ssid[0] == '\0' || !bssid) return false;
+
+    uint32_t nowSecs = (uint32_t)time(nullptr);
+
+    int idx = findIndex(ssid, bssid);
+    if (idx < 0) {
+        if (_count >= MAX_HINTS) evictLRUSlot();
+        idx = _count;
+        _count++;
+        memset(&_hints[idx], 0, sizeof(_hints[idx]));
+        strncpy(_hints[idx].ssid, ssid, sizeof(_hints[idx].ssid) - 1);
+        memcpy(_hints[idx].bssid, bssid, 6);
+    }
+
+    _hints[idx].channel        = channel;
+    _hints[idx].pmf_disable    = pmf_disable ? 1 : 0;
+    _hints[idx].last_used_secs = nowSecs;
+    return true;
+}
+
+int NetworkHints::evictStale(uint32_t nowSecs, uint32_t maxAgeSecs) {
+    if (nowSecs <= maxAgeSecs) return 0;  // clock unsynced or unreasonable
+    uint32_t cutoff = nowSecs - maxAgeSecs;
+    int dropped = 0;
+    int dst = 0;
+    for (int src = 0; src < _count; src++) {
+        if (_hints[src].last_used_secs < cutoff) {
+            dropped++;
+            continue;
+        }
+        if (dst != src) _hints[dst] = _hints[src];
+        dst++;
+    }
+    for (int i = dst; i < _count; i++) {
+        memset(&_hints[i], 0, sizeof(_hints[i]));
+    }
+    _count = dst;
+    if (dropped > 0) LOG_INFOF("[Hints] Evicted %d stale hint(s)", dropped);
+    return dropped;
+}
+
+void NetworkHints::clear() {
+    memset(_hints, 0, sizeof(_hints));
+    _count = 0;
+}
+
+const SavedNetworkHint* NetworkHints::at(int idx) const {
+    if (idx < 0 || idx >= _count) return nullptr;
+    return &_hints[idx];
+}
+
+void NetworkHints::evictLRUSlot() {
+    if (_count == 0) return;
+    int victim = 0;
+    for (int i = 1; i < _count; i++) {
+        if (_hints[i].last_used_secs < _hints[victim].last_used_secs) victim = i;
+    }
+
+    for (int i = victim; i < _count - 1; i++) {
+        _hints[i] = _hints[i + 1];
+    }
+    _count--;
+    memset(&_hints[_count], 0, sizeof(_hints[_count]));
+}

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -13,6 +13,7 @@ extern NetworkHints networkHints; // defined in main.cpp
 
 volatile uint8_t WiFiManager::_lastDisconnectReason = 0;
 volatile bool    WiFiManager::_hintRefreshPending  = false;
+volatile uint8_t WiFiManager::_apClientCount       = 0;
 
 WiFiManager::WiFiManager()
     : connected(false), mdnsStarted(false), apMode(false),
@@ -22,7 +23,8 @@ WiFiManager::WiFiManager()
       _candidateCount(0), _candidateIndex(0), _candidateRetries(0),
       _pendingConfig(nullptr),
       _pendingPmfDisable(false),
-      _lastRoamCheckMs(0), _lowRssiCount(0), _roamSuspended(false) {}
+      _lastRoamCheckMs(0), _lowRssiCount(0), _roamSuspended(false),
+      _apTeardownEligibleSinceMs(0) {}
 
 void WiFiManager::startAP() {
     LOG("Starting AP Mode (CPAP-AutoSync) for configuration");
@@ -196,15 +198,33 @@ void WiFiManager::onWiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
             
         case ARDUINO_EVENT_WIFI_STA_GOT_IP:
             LOG_INFOF("WiFi Event: Got IP address: %s", WiFi.localIP().toString().c_str());
-            // Fires on every (re)association regardless of who initiated it
-            // pollConnect() consumes the flag and refreshes hint record for the current AP.
+            // Fires on every (re)association regardless of who initiated it,
+            // including NetworkRecovery's tryCoordinatedWifiCycle and any
+            // supplicant-driven roam.  pollConnect() consumes the flag and
+            // refreshes the NetworkHints record for the current AP.
             _hintRefreshPending = true;
             break;
             
         case ARDUINO_EVENT_WIFI_STA_LOST_IP:
             LOG_WARN("WiFi Event: Lost IP address");
             break;
-            
+
+        case ARDUINO_EVENT_WIFI_AP_STACONNECTED: {
+            uint8_t n = _apClientCount;
+            if (n < 0xFF) _apClientCount = n + 1;
+            LOG_INFOF("WiFi Event: AP client connected (total: %u)",
+                      (unsigned)_apClientCount);
+            break;
+        }
+
+        case ARDUINO_EVENT_WIFI_AP_STADISCONNECTED: {
+            uint8_t n = _apClientCount;
+            if (n > 0) _apClientCount = n - 1;
+            LOG_INFOF("WiFi Event: AP client disconnected (remaining: %u)",
+                      (unsigned)_apClientCount);
+            break;
+        }
+
         default:
             LOG_DEBUGF("WiFi Event: Unhandled event %d", event);
             break;
@@ -292,7 +312,10 @@ void WiFiManager::logConnectFailure() {
 }
 
 // Update the NetworkHints record for the AP we are currently associated with.
-// The PMF flag is preserved from the existing hint since we don't have authoritative information about it in this path.
+// Called from pollConnect when STA_GOT_IP fired without going through our own
+// terminateConnect (i.e. NetworkRecovery's tryCoordinatedWifiCycle, or a
+// supplicant-driven roam).  The PMF flag is preserved from the existing hint
+// since we don't have authoritative information about it in this path.
 void WiFiManager::refreshHintForCurrentConnection() {
     if (!_pendingConfig || WiFi.status() != WL_CONNECTED) return;
     String currentSsid = WiFi.SSID();
@@ -491,7 +514,7 @@ bool WiFiManager::startCurrentCandidate() {
         }
     }
 
-    // Apply deferred TX power AFTER WiFi.begin() — WiFi.mode(WIFI_STA) is async
+    // Apply deferred TX power AFTER WiFi.begin() - WiFi.mode(WIFI_STA) is async
     // and the STA isn't fully started until the STA_START event fires. begin()
     // blocks until STA is active, so setTxPower() works reliably here.
     // This caps TX power during the association/DHCP phase.
@@ -687,6 +710,8 @@ void WiFiManager::roamingTick() {
     if (!_pendingConfig || _pendingConfig->getWifiNetworkCount() < 2) return;
     if (_roamSuspended) return;
     if (WiFi.status() != WL_CONNECTED) return;
+    // Don't scan while a user is connected to the captive AP
+    if (_apClientCount > 0) return;
 
     uint32_t now = millis();
     if (now - _lastRoamCheckMs < ROAM_CHECK_INTERVAL_MS) return;
@@ -704,6 +729,36 @@ void WiFiManager::roamingTick() {
         _lowRssiCount = 0;
         kickRoamScan();
     }
+}
+
+// Stable-quiet AP teardown
+//
+// Boot-fallback path: when the boot connectStation() failed and apMode was
+// raised, the main loop continues to retry STA in the background.  Once STA
+// gets back, we want to tear the AP down again so the radio drops back to
+// pure STA (lower idle current, no broadcast beacons). But only after a
+// stable window in which (a) STA stays continuously CONNECTED and (b) no
+// client is talking to the AP, otherwise we'd kick a user mid-config or
+// drop the AP only to bring it back if STA flaps right after.
+bool WiFiManager::shouldTearDownAP() {
+    if (!apMode) {
+        _apTeardownEligibleSinceMs = 0;
+        return false;
+    }
+    bool staConnected  = (_connectPhase == ConnectPhase::CONNECTED &&
+                          WiFi.status() == WL_CONNECTED);
+    bool clientsActive = (_apClientCount > 0);
+    if (!staConnected || clientsActive) {
+        _apTeardownEligibleSinceMs = 0;
+        return false;
+    }
+    if (_apTeardownEligibleSinceMs == 0) {
+        _apTeardownEligibleSinceMs = millis();
+        LOGF("[AP] STA back online with no AP clients - starting %u s teardown timer",
+             (unsigned)(AP_TEARDOWN_QUIET_MS / 1000));
+        return false;
+    }
+    return (millis() - _apTeardownEligibleSinceMs) >= AP_TEARDOWN_QUIET_MS;
 }
 
 void WiFiManager::kickRoamScan() {
@@ -766,9 +821,10 @@ void WiFiManager::processRoamScanResults() {
         _candidates[j + 1] = tmp;
     }
 
-    // Locate the currently-associated AP within the list. If it's not there, stay
-    // a partial scan is not a sound basis for disconnecting. When found, the cascade
-    // already includes us as the natural final fallback in RSSI order.
+    // Locate the currently-associated AP within the list.  If it's not there
+    // (scan didn't see ourselves - rare), stay: a partial scan is not a sound
+    // basis for disconnecting.  When found, the cascade already includes us
+    // as the natural final fallback in RSSI order.
     const uint8_t* currentBssid = WiFi.BSSID();
     int currentIdx = -1;
     if (currentBssid) {

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -686,70 +686,87 @@ void WiFiManager::processRoamScanResults() {
         return;
     }
 
-    // Find the strongest visible AP that matches a configured SSID (any BSSID).
-    int8_t  bestRssi  = -127;
-    int     bestIdx   = -1;
-    uint8_t bestSlot  = 0xFF;
+    // Build the full ranked candidate list - same logic as processScanResults
+    // but used here to decide "stay vs switch" and (on switch) to drive
+    // best-first iteration through onCurrentCandidateFailed.
     int cfgCount = _pendingConfig->getWifiNetworkCount();
-    for (int i = 0; i < n; i++) {
+    _candidateCount = 0;
+    for (int i = 0; i < n && _candidateCount < MAX_CANDIDATES; i++) {
         String visibleSsid = WiFi.SSID(i);
         for (int slot = 0; slot < cfgCount; slot++) {
             if (visibleSsid != _pendingConfig->getWifiSSID(slot)) continue;
-            int rssi = WiFi.RSSI(i);
-            if (rssi > bestRssi) {
-                bestRssi = (int8_t)rssi;
-                bestIdx  = i;
-                bestSlot = (uint8_t)slot;
-            }
+            Candidate& c = _candidates[_candidateCount];
+            c.configSlot = (uint8_t)slot;
+            const uint8_t* bssid = WiFi.BSSID(i);
+            if (bssid) memcpy(c.bssid, bssid, 6);
+            else       memset(c.bssid, 0, 6);
+            c.channel = (uint8_t)WiFi.channel(i);
+            c.rssi    = (int8_t)WiFi.RSSI(i);
+            _candidateCount++;
             break;
         }
     }
 
-    if (bestIdx < 0) {
+    WiFi.scanDelete();
+
+    if (_candidateCount == 0) {
         LOG_WARN("WiFi roam scan: no known networks visible");
-        WiFi.scanDelete();
         _connectPhase = ConnectPhase::CONNECTED;
         return;
     }
 
-    // Hysteresis check: only switch if the candidate beats current by margin.
-    int8_t currentRssi = (int8_t)WiFi.RSSI();
+    // Sort candidates by RSSI desc (insertion sort).
+    for (int i = 1; i < _candidateCount; i++) {
+        Candidate tmp = _candidates[i];
+        int j = i - 1;
+        while (j >= 0 && _candidates[j].rssi < tmp.rssi) {
+            _candidates[j + 1] = _candidates[j];
+            j--;
+        }
+        _candidates[j + 1] = tmp;
+    }
+
+    // Locate the currently-associated AP within the list. If it's not there, stay
+    // a partial scan is not a sound basis for disconnecting. When found, the cascade
+    // already includes us as the natural final fallback in RSSI order.
     const uint8_t* currentBssid = WiFi.BSSID();
-    const uint8_t* candidateBssid = WiFi.BSSID(bestIdx);
-    bool sameAp = (currentBssid && candidateBssid &&
-                   memcmp(currentBssid, candidateBssid, 6) == 0);
+    int currentIdx = -1;
+    if (currentBssid) {
+        for (int i = 0; i < _candidateCount; i++) {
+            if (memcmp(_candidates[i].bssid, currentBssid, 6) == 0) {
+                currentIdx = i;
+                break;
+            }
+        }
+    }
+    if (currentIdx < 0) {
+        LOG_WARN("WiFi roam scan: current AP missing from scan results - staying");
+        _connectPhase = ConnectPhase::CONNECTED;
+        return;
+    }
 
-    if (sameAp) {
+    int8_t currentRssi = _candidates[currentIdx].rssi;
+    Candidate& best = _candidates[0];
+
+    if (currentIdx == 0) {
         LOG_INFO("WiFi roam: best candidate is current AP - staying");
-        WiFi.scanDelete();
         _connectPhase = ConnectPhase::CONNECTED;
         return;
     }
-
-    if (bestRssi < currentRssi + ROAM_HYSTERESIS_DB) {
+    if (best.rssi < currentRssi + ROAM_HYSTERESIS_DB) {
         LOGF("WiFi roam: candidate %d dBm vs current %d dBm (need >=%d delta) - staying",
-             bestRssi, currentRssi, ROAM_HYSTERESIS_DB);
-        WiFi.scanDelete();
+             best.rssi, currentRssi, ROAM_HYSTERESIS_DB);
         _connectPhase = ConnectPhase::CONNECTED;
         return;
     }
 
-    LOGF("WiFi roam: switching to '%s' %d dBm (was %d dBm)",
-         _pendingConfig->getWifiSSID(bestSlot).c_str(), bestRssi, currentRssi);
+    LOGF("WiFi roam: switching to '%s' %d dBm (was %d dBm); %u candidate(s) ranked",
+         _pendingConfig->getWifiSSID(best.configSlot).c_str(),
+         best.rssi, currentRssi, _candidateCount);
 
-    // Build a single-candidate list pointing at the new AP, disconnect, and
-    // reuse the standard candidate-start machinery to (re)connect.
-    Candidate& c = _candidates[0];
-    c.configSlot = bestSlot;
-    if (candidateBssid) memcpy(c.bssid, candidateBssid, 6);
-    else                memset(c.bssid, 0, 6);
-    c.channel = (uint8_t)WiFi.channel(bestIdx);
-    c.rssi    = bestRssi;
-    _candidateCount   = 1;
     _candidateIndex   = 0;
     _candidateRetries = 0;
 
-    WiFi.scanDelete();
     WiFi.disconnect(false);  // disconnect from current AP, keep STA up
     delay(100);
     startCurrentCandidate();

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -13,7 +13,9 @@ WiFiManager::WiFiManager()
     : connected(false), mdnsStarted(false), apMode(false),
       _pendingTxPower(0), _hasPendingTxPower(false),
       _connectPhase(ConnectPhase::IDLE), _phaseStartMs(0),
-      _consecutiveFailures(0) {}
+      _consecutiveFailures(0),
+      _candidateCount(0), _candidateIndex(0), _candidateRetries(0),
+      _pendingConfig(nullptr) {}
 
 void WiFiManager::startAP() {
     LOG("Starting AP Mode (CPAP-AutoSync) for configuration");
@@ -214,7 +216,8 @@ void WiFiManager::enterPhase(ConnectPhase newPhase) {
 }
 
 bool WiFiManager::isConnectInProgress() const {
-    return _connectPhase == ConnectPhase::CONNECTING ||
+    return _connectPhase == ConnectPhase::SCANNING  ||
+           _connectPhase == ConnectPhase::CONNECTING ||
            _connectPhase == ConnectPhase::PMF_RETRY;
 }
 
@@ -260,7 +263,7 @@ void WiFiManager::enterPmfRetry() {
     LOG_WARN("PMF association comeback timeout (reason 208) - retrying with PMF disabled");
     wifi_config_t wifi_conf;
     if (esp_wifi_get_config(WIFI_IF_STA, &wifi_conf) != ESP_OK) {
-        terminateConnect(ConnectPhase::FAILED);
+        onCurrentCandidateFailed();
         return;
     }
     wifi_conf.sta.pmf_cfg.capable  = false;
@@ -271,28 +274,158 @@ void WiFiManager::enterPmfRetry() {
     enterPhase(ConnectPhase::PMF_RETRY);
 }
 
-bool WiFiManager::beginConnect(const String& ssid, const String& password, const String& hostname) {
+// Multi-SSID candidate pipeline
+//
+// beginConnect(Config&) prepares common radio state once, then either
+// (1 network) builds a single candidate with no BSSID hint and connects, or
+// (2+ networks) kicks an async scan; pollConnect() processes scan completion,
+// builds candidate list (visible APs intersected with configured SSIDs,
+// sorted by RSSI), and tries each candidate in turn with up to
+// CANDIDATE_MAX_RETRIES retries before falling back to the next.
+
+void WiFiManager::prepareSingleCandidate(uint8_t configSlot) {
+    _candidates[0].configSlot = configSlot;
+    memset(_candidates[0].bssid, 0, 6);
+    _candidates[0].channel = 0;
+    _candidates[0].rssi    = 0;
+    _candidateCount   = 1;
+    _candidateIndex   = 0;
+    _candidateRetries = 0;
+}
+
+void WiFiManager::kickScan() {
+    LOGF("WiFi: scanning for %d configured network(s)...", _pendingConfig->getWifiNetworkCount());
+    int rc = WiFi.scanNetworks(true /*async*/, false /*show_hidden*/);
+    if (rc < 0 && rc != WIFI_SCAN_RUNNING) {
+        LOG_ERRORF("WiFi scan kick failed: %d", rc);
+        terminateConnect(ConnectPhase::FAILED);
+        return;
+    }
+    enterPhase(ConnectPhase::SCANNING);
+}
+
+void WiFiManager::processScanResults() {
+    int n = WiFi.scanComplete();
+    if (n < 0) {
+        LOG_WARNF("processScanResults() called with rc=%d", n);
+        WiFi.scanDelete();
+        terminateConnect(ConnectPhase::FAILED);
+        return;
+    }
+
+    int cfgCount = _pendingConfig->getWifiNetworkCount();
+    _candidateCount = 0;
+
+    for (int i = 0; i < n && _candidateCount < MAX_CANDIDATES; i++) {
+        String visibleSsid = WiFi.SSID(i);
+        for (int slot = 0; slot < cfgCount; slot++) {
+            if (visibleSsid != _pendingConfig->getWifiSSID(slot)) continue;
+            Candidate& c = _candidates[_candidateCount];
+            c.configSlot = (uint8_t)slot;
+            const uint8_t* bssid = WiFi.BSSID(i);
+            if (bssid) memcpy(c.bssid, bssid, 6);
+            else       memset(c.bssid, 0, 6);
+            c.channel = (uint8_t)WiFi.channel(i);
+            c.rssi    = (int8_t)WiFi.RSSI(i);
+            _candidateCount++;
+            break;  // one scan result matches at most one configured slot
+        }
+    }
+
+    WiFi.scanDelete();
+    LOGF("WiFi scan: %d known of %d visible", _candidateCount, n);
+
+    if (_candidateCount == 0) {
+        terminateConnect(ConnectPhase::FAILED);
+        return;
+    }
+
+    // Sort candidates by RSSI desc (insertion sort - tiny array)
+    for (int i = 1; i < _candidateCount; i++) {
+        Candidate tmp = _candidates[i];
+        int j = i - 1;
+        while (j >= 0 && _candidates[j].rssi < tmp.rssi) {
+            _candidates[j + 1] = _candidates[j];
+            j--;
+        }
+        _candidates[j + 1] = tmp;
+    }
+
+    LOGF("WiFi: best candidate '%s' %d dBm",
+         _pendingConfig->getWifiSSID(_candidates[0].configSlot).c_str(),
+         _candidates[0].rssi);
+
+    _candidateIndex   = 0;
+    _candidateRetries = 0;
+    startCurrentCandidate();
+}
+
+bool WiFiManager::startCurrentCandidate() {
+    if (_candidateIndex >= _candidateCount || !_pendingConfig) {
+        terminateConnect(ConnectPhase::FAILED);
+        return false;
+    }
+    Candidate& c = _candidates[_candidateIndex];
+    _pendingSsid     = _pendingConfig->getWifiSSID(c.configSlot);
+    _pendingPassword = _pendingConfig->getWifiPassword(c.configSlot);
+    _lastDisconnectReason = 0;
+
+    bool hasHint = (c.channel > 0);
+    if (hasHint) {
+        LOGF("WiFi: connecting to '%s' (ch=%u, RSSI %d dBm)",
+             _pendingSsid.c_str(), c.channel, c.rssi);
+        WiFi.begin(_pendingSsid.c_str(), _pendingPassword.c_str(), c.channel, c.bssid);
+    } else {
+        LOGF("WiFi: connecting to '%s'", _pendingSsid.c_str());
+        WiFi.begin(_pendingSsid.c_str(), _pendingPassword.c_str());
+    }
+
+    // Apply deferred TX power AFTER WiFi.begin() — WiFi.mode(WIFI_STA) is async
+    // and the STA isn't fully started until the STA_START event fires. begin()
+    // blocks until STA is active, so setTxPower() works reliably here.
+    // This caps TX power during the association/DHCP phase.
+    if (_hasPendingTxPower) {
+        WiFi.setTxPower((wifi_power_t)_pendingTxPower);
+        LOG_DEBUGF("WiFi TX power applied: %d (deferred from applyTxPowerEarly)", (int)_pendingTxPower);
+        _hasPendingTxPower = false;
+    }
+
+    enterPhase(ConnectPhase::CONNECTING);
+    return true;
+}
+
+void WiFiManager::onCurrentCandidateFailed() {
+    if (_candidateRetries < CANDIDATE_MAX_RETRIES) {
+        _candidateRetries++;
+        LOGF("WiFi: retry %u/%u on current candidate", _candidateRetries, CANDIDATE_MAX_RETRIES);
+        startCurrentCandidate();
+        return;
+    }
+    _candidateIndex++;
+    _candidateRetries = 0;
+    if (_candidateIndex < _candidateCount) {
+        LOGF("WiFi: trying next candidate (%u/%u)", _candidateIndex + 1, _candidateCount);
+        startCurrentCandidate();
+        return;
+    }
+    terminateConnect(ConnectPhase::FAILED);
+}
+
+bool WiFiManager::beginConnect(const Config& cfg) {
     if (isConnectInProgress()) {
         LOG_WARN("beginConnect() called while attempt already in progress");
         return false;
     }
-    if (ssid.isEmpty()) {
-        LOG_ERROR("Cannot connect to WiFi: SSID is empty");
+    int n = cfg.getWifiNetworkCount();
+    if (n <= 0) {
+        LOG_ERROR("Cannot connect to WiFi: no networks configured");
         Logger::getInstance().dumpSavedLogs("wifi_config_error");
         return false;
     }
-    if (ssid.length() > 32) {
-        LOG_ERROR("Cannot connect to WiFi: SSID exceeds 32 character limit");
-        LOGF("SSID length: %d characters", ssid.length());
-        Logger::getInstance().dumpSavedLogs("wifi_config_error");
-        return false;
-    }
-    if (password.isEmpty()) {
-        LOG_WARN("WiFi password is empty - attempting open network connection");
-    }
 
-    LOGF("Connecting to WiFi: %s", ssid.c_str());
+    LOGF("WiFi: %d configured network(s)", n);
 
+    const String& hostname = cfg.getHostname();
     if (!hostname.isEmpty()) {
         WiFi.setHostname(hostname.c_str());
         LOGF("DHCP Hostname set to: %s", hostname.c_str());
@@ -313,29 +446,47 @@ bool WiFiManager::beginConnect(const String& ssid, const String& password, const
     // ScheduleManager decides whether to use them based on config priority.
     esp_sntp_servermode_dhcp(true);
 
-    _pendingSsid     = ssid;
-    _pendingPassword = password;
-    _lastDisconnectReason = 0;
+    _pendingConfig    = &cfg;
+    _pendingHostname  = cfg.getHostname();
+    _candidateCount   = 0;
+    _candidateIndex   = 0;
+    _candidateRetries = 0;
 
-    WiFi.begin(ssid.c_str(), password.c_str());
-
-    // Apply deferred TX power AFTER WiFi.begin() — WiFi.mode(WIFI_STA) is async
-    // and the STA isn't fully started until the STA_START event fires. begin()
-    // blocks until STA is active, so setTxPower() works reliably here.
-    // This caps TX power during the association/DHCP phase.
-    if (_hasPendingTxPower) {
-        WiFi.setTxPower((wifi_power_t)_pendingTxPower);
-        LOG_DEBUGF("WiFi TX power applied: %d (deferred from applyTxPowerEarly)", (int)_pendingTxPower);
-        _hasPendingTxPower = false;
+    if (n == 1) {
+        // Single SSID: skip scan, no BSSID hint.
+        prepareSingleCandidate(0);
+        return startCurrentCandidate();
     }
-
-    enterPhase(ConnectPhase::CONNECTING);
+    // Multi-SSID: scan first.
+    kickScan();
     return true;
 }
 
 void WiFiManager::pollConnect() {
     if (!isConnectInProgress()) return;
 
+    if (_connectPhase == ConnectPhase::SCANNING) {
+        int rc = WiFi.scanComplete();
+        if (rc >= 0) {
+            processScanResults();
+            return;
+        }
+        if (rc == WIFI_SCAN_FAILED) {
+            LOG_ERROR("WiFi scan failed");
+            WiFi.scanDelete();
+            terminateConnect(ConnectPhase::FAILED);
+            return;
+        }
+        if (millis() - _phaseStartMs >= SCAN_TIMEOUT_MS) {
+            LOG_WARN("WiFi scan timeout");
+            WiFi.scanDelete();
+            terminateConnect(ConnectPhase::FAILED);
+            return;
+        }
+        return;  // scan still running
+    }
+
+    // CONNECTING or PMF_RETRY
     wl_status_t status = WiFi.status();
     uint32_t elapsed = millis() - _phaseStartMs;
 
@@ -343,34 +494,24 @@ void WiFiManager::pollConnect() {
         terminateConnect(ConnectPhase::CONNECTED);
         return;
     }
-
-    // Terminal radio states: SSID not in range / auth failure.  No point waiting.
     if (status == WL_NO_SSID_AVAIL || status == WL_CONNECT_FAILED) {
-        // Reason 208 only fires when the AP is reachable but rejects PMF.
-        // If we got here with NO_SSID_AVAIL or CONNECT_FAILED, PMF retry won't help.
-        terminateConnect(ConnectPhase::FAILED);
+        onCurrentCandidateFailed();
         return;
     }
-
-    // Phase timeout reached.
     if (elapsed >= CONNECT_PHASE_TIMEOUT_MS) {
         if (_connectPhase == ConnectPhase::CONNECTING &&
             _lastDisconnectReason == WIFI_REASON_ASSOC_COMEBACK_TIME_TOO_LONG) {
-            // Switch to PMF retry sub-state.  Don't terminate yet.
             enterPmfRetry();
             return;
         }
-        terminateConnect(ConnectPhase::FAILED);
+        onCurrentCandidateFailed();
         return;
     }
-
     // Still in progress - nothing to do this tick.
 }
 
-bool WiFiManager::connectStation(const String& ssid, const String& password, const String& hostname) {
-    if (!beginConnect(ssid, password, hostname)) {
-        return false;
-    }
+bool WiFiManager::connectStation(const Config& cfg) {
+    if (!beginConnect(cfg)) return false;
     while (isConnectInProgress()) {
         pollConnect();
         if (isConnectInProgress()) delay(50);

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -9,7 +9,10 @@
 
 volatile uint8_t WiFiManager::_lastDisconnectReason = 0;
 
-WiFiManager::WiFiManager() : connected(false), mdnsStarted(false), apMode(false), _pendingTxPower(0), _hasPendingTxPower(false) {}
+WiFiManager::WiFiManager()
+    : connected(false), mdnsStarted(false), apMode(false),
+      _pendingTxPower(0), _hasPendingTxPower(false),
+      _connectPhase(ConnectPhase::IDLE), _phaseStartMs(0) {}
 
 void WiFiManager::startAP() {
     LOG("Starting AP Mode (CPAP-AutoSync) for configuration");
@@ -195,48 +198,113 @@ void WiFiManager::onWiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
     }
 }
 
-bool WiFiManager::connectStation(const String& ssid, const String& password, const String& hostname) {
-    // Validate SSID before attempting connection
+// Connection state machine
+//
+// beginConnect() validates args, sets WIFI mode (STA, or AP_STA if a softAP
+// is already running), kicks off WiFi.begin(), and transitions to CONNECTING.
+// pollConnect() advances the state machine on each call from the main loop:
+// reads WiFi.status() and the last disconnect reason, handles the PMF retry
+// sub-state, and transitions to CONNECTED or FAILED on terminal results.
+// connectStation() is a synchronous wrapper used by the boot path.
+
+void WiFiManager::enterPhase(ConnectPhase newPhase) {
+    _connectPhase = newPhase;
+    _phaseStartMs = millis();
+}
+
+bool WiFiManager::isConnectInProgress() const {
+    return _connectPhase == ConnectPhase::CONNECTING ||
+           _connectPhase == ConnectPhase::PMF_RETRY;
+}
+
+void WiFiManager::terminateConnect(ConnectPhase result) {
+    _connectPhase = result;
+    _phaseStartMs = millis();
+    if (result == ConnectPhase::CONNECTED) {
+        connected = true;
+        LOG("WiFi connected");
+        LOGF("IP address: %s", WiFi.localIP().toString().c_str());
+    } else {
+        connected = false;
+        logConnectFailure();
+        Logger::getInstance().dumpSavedLogs("wifi_connection_failed");
+    }
+}
+
+void WiFiManager::logConnectFailure() {
+    LOGF("WiFi connection failed, status: %d", WiFi.status());
+    switch (WiFi.status()) {
+        case WL_NO_SSID_AVAIL:  LOG_ERROR("WiFi failure: SSID not found"); break;
+        case WL_CONNECT_FAILED: LOG_ERROR("WiFi failure: Connection failed (wrong password?)"); break;
+        case WL_CONNECTION_LOST:LOG_ERROR("WiFi failure: Connection lost"); break;
+        case WL_DISCONNECTED:   LOG_ERROR("WiFi failure: Disconnected"); break;
+        default:                LOGF("WiFi failure: Unknown status %d", WiFi.status()); break;
+    }
+}
+
+void WiFiManager::enterPmfRetry() {
+    LOG_WARN("PMF association comeback timeout (reason 208) - retrying with PMF disabled");
+    wifi_config_t wifi_conf;
+    if (esp_wifi_get_config(WIFI_IF_STA, &wifi_conf) != ESP_OK) {
+        terminateConnect(ConnectPhase::FAILED);
+        return;
+    }
+    wifi_conf.sta.pmf_cfg.capable  = false;
+    wifi_conf.sta.pmf_cfg.required = false;
+    esp_wifi_set_config(WIFI_IF_STA, &wifi_conf);
+    esp_wifi_disconnect();
+    esp_wifi_connect();
+    enterPhase(ConnectPhase::PMF_RETRY);
+}
+
+bool WiFiManager::beginConnect(const String& ssid, const String& password, const String& hostname) {
+    if (isConnectInProgress()) {
+        LOG_WARN("beginConnect() called while attempt already in progress");
+        return false;
+    }
     if (ssid.isEmpty()) {
         LOG_ERROR("Cannot connect to WiFi: SSID is empty");
         Logger::getInstance().dumpSavedLogs("wifi_config_error");
         return false;
     }
-    
     if (ssid.length() > 32) {
         LOG_ERROR("Cannot connect to WiFi: SSID exceeds 32 character limit");
         LOGF("SSID length: %d characters", ssid.length());
         Logger::getInstance().dumpSavedLogs("wifi_config_error");
         return false;
     }
-    
     if (password.isEmpty()) {
         LOG_WARN("WiFi password is empty - attempting open network connection");
     }
-    
+
     LOGF("Connecting to WiFi: %s", ssid.c_str());
-    LOGF("SSID length: %d characters", ssid.length());
 
     if (!hostname.isEmpty()) {
         WiFi.setHostname(hostname.c_str());
         LOGF("DHCP Hostname set to: %s", hostname.c_str());
     }
-    
-    WiFi.mode(WIFI_STA);
+
+    // AP+STA coexistence: if a softAP is already running, switch to AP_STA mode
+    // so the AP keeps broadcasting while STA scans/connects. Otherwise plain STA.
+    WiFi.mode(apMode ? WIFI_AP_STA : WIFI_STA);
 
     // ── Power optimization: disable 802.11b (DSSS) ──
     // 802.11b uses up to 370 mA peak TX. Restricting to 802.11g/n (OFDM)
     // caps peak TX current to ~205-250 mA. All modern routers support g/n.
     esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11G | WIFI_PROTOCOL_11N);
     LOG_DEBUG("WiFi protocol restricted to 802.11g/n (802.11b disabled)");
-    
+
     // Enable DHCP NTP server capture before connecting.
     // This passively stores any NTP servers the router advertises;
     // ScheduleManager decides whether to use them based on config priority.
     esp_sntp_servermode_dhcp(true);
 
+    _pendingSsid     = ssid;
+    _pendingPassword = password;
+    _lastDisconnectReason = 0;
+
     WiFi.begin(ssid.c_str(), password.c_str());
-    
+
     // Apply deferred TX power AFTER WiFi.begin() — WiFi.mode(WIFI_STA) is async
     // and the STA isn't fully started until the STA_START event fires. begin()
     // blocks until STA is active, so setTxPower() works reliably here.
@@ -247,82 +315,53 @@ bool WiFiManager::connectStation(const String& ssid, const String& password, con
         _hasPendingTxPower = false;
     }
 
-    _lastDisconnectReason = 0;
-    int attempts = 0;
-    while (attempts < 30) {
-        wl_status_t status = WiFi.status();
-        if (status == WL_CONNECTED) break;
-        // Radio gave up - no point waiting the full timeout.
-        // The PMF retry path still runs if the disconnect reason warrants it.
-        if (status == WL_NO_SSID_AVAIL || status == WL_CONNECT_FAILED) break;
-        delay(500);
-        LOG_DEBUG(".");
-        attempts++;
+    enterPhase(ConnectPhase::CONNECTING);
+    return true;
+}
+
+void WiFiManager::pollConnect() {
+    if (!isConnectInProgress()) return;
+
+    wl_status_t status = WiFi.status();
+    uint32_t elapsed = millis() - _phaseStartMs;
+
+    if (status == WL_CONNECTED) {
+        terminateConnect(ConnectPhase::CONNECTED);
+        return;
     }
 
-    // ── PMF fallback: reason 208 (ASSOC_COMEBACK_TIME_TOO_LONG) ──
-    // ESP-IDF 5.x sets PMF (Protected Management Frames / 802.11w) capable=true
-    // by default. Some WiFi 6 / WPA3-transitional routers send an association
-    // comeback time that exceeds the ESP-IDF threshold, causing reason 208.
-    // This didn't exist in ESP-IDF 4.x. Retry with PMF disabled.
-    if (WiFi.status() != WL_CONNECTED &&
-        _lastDisconnectReason == WIFI_REASON_ASSOC_COMEBACK_TIME_TOO_LONG) {
-        LOG_WARN("PMF association comeback timeout (reason 208) — retrying with PMF disabled");
-        wifi_config_t wifi_conf;
-        if (esp_wifi_get_config(WIFI_IF_STA, &wifi_conf) == ESP_OK) {
-            wifi_conf.sta.pmf_cfg.capable = false;
-            wifi_conf.sta.pmf_cfg.required = false;
-            esp_wifi_set_config(WIFI_IF_STA, &wifi_conf);
-            esp_wifi_disconnect();
-            esp_wifi_connect();
-            attempts = 0;
-            while (attempts < 30) {
-                wl_status_t status = WiFi.status();
-                if (status == WL_CONNECTED) break;
-                if (status == WL_NO_SSID_AVAIL || status == WL_CONNECT_FAILED) break;
-                delay(500);
-                LOG_DEBUG(".");
-                attempts++;
-            }
-            if (WiFi.status() == WL_CONNECTED) {
-                LOG_WARN("Connected after disabling PMF — router may not fully support 802.11w");
-            }
-        }
+    // Terminal radio states: SSID not in range / auth failure.  No point waiting.
+    if (status == WL_NO_SSID_AVAIL || status == WL_CONNECT_FAILED) {
+        // Reason 208 only fires when the AP is reachable but rejects PMF.
+        // If we got here with NO_SSID_AVAIL or CONNECT_FAILED, PMF retry won't help.
+        terminateConnect(ConnectPhase::FAILED);
+        return;
     }
 
-    if (WiFi.status() == WL_CONNECTED) {
-        LOG("\nWiFi connected");
-        LOGF("IP address: %s", WiFi.localIP().toString().c_str());
-        connected = true;
-        return true;
-    } else {
-        LOG("\nWiFi connection failed");
-        LOGF("WiFi status: %d", WiFi.status());
-        
-        // Log detailed failure reason
-        switch (WiFi.status()) {
-            case WL_NO_SSID_AVAIL:
-                LOG_ERROR("WiFi failure: SSID not found");
-                break;
-            case WL_CONNECT_FAILED:
-                LOG_ERROR("WiFi failure: Connection failed (wrong password?)");
-                break;
-            case WL_CONNECTION_LOST:
-                LOG_ERROR("WiFi failure: Connection lost");
-                break;
-            case WL_DISCONNECTED:
-                LOG_ERROR("WiFi failure: Disconnected");
-                break;
-            default:
-                LOGF("WiFi failure: Unknown status %d", WiFi.status());
-                break;
+    // Phase timeout reached.
+    if (elapsed >= CONNECT_PHASE_TIMEOUT_MS) {
+        if (_connectPhase == ConnectPhase::CONNECTING &&
+            _lastDisconnectReason == WIFI_REASON_ASSOC_COMEBACK_TIME_TOO_LONG) {
+            // Switch to PMF retry sub-state.  Don't terminate yet.
+            enterPmfRetry();
+            return;
         }
-        
-        // Persist logs for critical connection failures
-        Logger::getInstance().dumpSavedLogs("wifi_connection_failed");
-        connected = false;
+        terminateConnect(ConnectPhase::FAILED);
+        return;
+    }
+
+    // Still in progress - nothing to do this tick.
+}
+
+bool WiFiManager::connectStation(const String& ssid, const String& password, const String& hostname) {
+    if (!beginConnect(ssid, password, hostname)) {
         return false;
     }
+    while (isConnectInProgress()) {
+        pollConnect();
+        if (isConnectInProgress()) delay(50);
+    }
+    return _connectPhase == ConnectPhase::CONNECTED;
 }
 
 bool WiFiManager::isConnected() const { 

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -20,7 +20,8 @@ WiFiManager::WiFiManager()
       _consecutiveFailures(0),
       _candidateCount(0), _candidateIndex(0), _candidateRetries(0),
       _pendingConfig(nullptr),
-      _pendingPmfDisable(false) {}
+      _pendingPmfDisable(false),
+      _lastRoamCheckMs(0), _lowRssiCount(0), _roamSuspended(false) {}
 
 void WiFiManager::startAP() {
     LOG("Starting AP Mode (CPAP-AutoSync) for configuration");
@@ -223,7 +224,8 @@ void WiFiManager::enterPhase(ConnectPhase newPhase) {
 bool WiFiManager::isConnectInProgress() const {
     return _connectPhase == ConnectPhase::SCANNING  ||
            _connectPhase == ConnectPhase::CONNECTING ||
-           _connectPhase == ConnectPhase::PMF_RETRY;
+           _connectPhase == ConnectPhase::PMF_RETRY  ||
+           _connectPhase == ConnectPhase::ROAM_SCAN;
 }
 
 void WiFiManager::terminateConnect(ConnectPhase result) {
@@ -313,24 +315,24 @@ void WiFiManager::prepareSingleCandidate(uint8_t configSlot) {
     _candidates[0].channel = 0;
     _candidates[0].rssi    = 0;
 
-   // Single-SSID path: no scan to source a BSSID/channel from. Try to find
-   // a hint for this SSID (any BSSID; pick the most recently used) so we can
-   // skip the radio's own scan during association.
-   if (_pendingConfig) {
-       const String& ssid = _pendingConfig->getWifiSSID(configSlot);
-       const SavedNetworkHint* best = nullptr;
-       for (int i = 0; i < networkHints.count(); i++) {
-           const SavedNetworkHint* h = networkHints.at(i);
-           if (h && strcmp(h->ssid, ssid.c_str()) == 0) {
-               if (!best || h->last_used_secs > best->last_used_secs) best = h;
-           }
-       }
-       if (best) {
-           memcpy(_candidates[0].bssid, best->bssid, 6);
-           _candidates[0].channel = best->channel;
-           LOGF("WiFi: using cached hint for '%s' (ch=%u)", ssid.c_str(), best->channel);
-       }
-   }
+    // Single-SSID path: no scan to source a BSSID/channel from. Try to find
+    // a hint for this SSID (any BSSID; pick the most recently used) so we can
+    // skip the radio's own scan during association.
+    if (_pendingConfig) {
+        const String& ssid = _pendingConfig->getWifiSSID(configSlot);
+        const SavedNetworkHint* best = nullptr;
+        for (int i = 0; i < networkHints.count(); i++) {
+            const SavedNetworkHint* h = networkHints.at(i);
+            if (h && strcmp(h->ssid, ssid.c_str()) == 0) {
+                if (!best || h->last_used_secs > best->last_used_secs) best = h;
+            }
+        }
+        if (best) {
+            memcpy(_candidates[0].bssid, best->bssid, 6);
+            _candidates[0].channel = best->channel;
+            LOGF("WiFi: using cached hint for '%s' (ch=%u)", ssid.c_str(), best->channel);
+        }
+    }
 
     _candidateCount   = 1;
     _candidateIndex   = 0;
@@ -536,7 +538,34 @@ bool WiFiManager::beginConnect(const Config& cfg) {
 }
 
 void WiFiManager::pollConnect() {
+    // Roaming maintenance while connected.
+    if (_connectPhase == ConnectPhase::CONNECTED) {
+        roamingTick();
+        return;
+    }
+
     if (!isConnectInProgress()) return;
+
+    if (_connectPhase == ConnectPhase::ROAM_SCAN) {
+        int rc = WiFi.scanComplete();
+        if (rc >= 0) {
+            processRoamScanResults();
+            return;
+        }
+        if (rc == WIFI_SCAN_FAILED) {
+            LOG_WARN("WiFi roam scan failed - staying connected");
+            WiFi.scanDelete();
+            _connectPhase = ConnectPhase::CONNECTED;
+            return;
+        }
+        if (millis() - _phaseStartMs >= SCAN_TIMEOUT_MS) {
+            LOG_WARN("WiFi roam scan timeout - staying connected");
+            WiFi.scanDelete();
+            _connectPhase = ConnectPhase::CONNECTED;
+            return;
+        }
+        return;  // scan still running
+    }
 
     if (_connectPhase == ConnectPhase::SCANNING) {
         int rc = WiFi.scanComplete();
@@ -590,6 +619,140 @@ bool WiFiManager::connectStation(const Config& cfg) {
         if (isConnectInProgress()) delay(50);
     }
     return _connectPhase == ConnectPhase::CONNECTED;
+}
+
+// Roaming with hysteresis
+//
+// While CONNECTED, sample RSSI every ROAM_CHECK_INTERVAL_MS. If RSSI stays
+// below ROAM_RSSI_THRESHOLD for ROAM_LOW_RSSI_COUNT consecutive samples,
+// trigger ROAM_SCAN to look for a stronger AP. Switch only if the best
+// alternative beats the current connection's RSSI by ROAM_HYSTERESIS_DB.
+// Suspended during upload sessions to avoid mid-TLS / mid-SMB disruption.
+
+void WiFiManager::suspendRoaming() {
+    _roamSuspended = true;
+    LOG_DEBUG("WiFi: roaming suspended");
+}
+
+void WiFiManager::resumeRoaming() {
+    _roamSuspended = false;
+    _lowRssiCount = 0;
+    _lastRoamCheckMs = millis();  // restart RSSI sampling window
+    LOG_DEBUG("WiFi: roaming resumed");
+}
+
+void WiFiManager::roamingTick() {
+    // Roaming requires multiple configured networks, an active connection,
+    // and not being suspended (i.e. not mid-upload).
+    if (!_pendingConfig || _pendingConfig->getWifiNetworkCount() < 2) return;
+    if (_roamSuspended) return;
+    if (WiFi.status() != WL_CONNECTED) return;
+
+    uint32_t now = millis();
+    if (now - _lastRoamCheckMs < ROAM_CHECK_INTERVAL_MS) return;
+    _lastRoamCheckMs = now;
+
+    int rssi = WiFi.RSSI();
+    if (rssi >= ROAM_RSSI_THRESHOLD) {
+        _lowRssiCount = 0;
+        return;
+    }
+
+    _lowRssiCount++;
+    LOGF("WiFi: low RSSI %d dBm (%u/%u)", rssi, _lowRssiCount, ROAM_LOW_RSSI_COUNT);
+    if (_lowRssiCount >= ROAM_LOW_RSSI_COUNT) {
+        _lowRssiCount = 0;
+        kickRoamScan();
+    }
+}
+
+void WiFiManager::kickRoamScan() {
+    LOG_INFO("WiFi: triggering roam scan");
+    int rc = WiFi.scanNetworks(true /*async*/, false /*show_hidden*/);
+    if (rc < 0 && rc != WIFI_SCAN_RUNNING) {
+        LOG_ERRORF("WiFi roam scan kick failed: %d", rc);
+        return;  // stay CONNECTED
+    }
+    enterPhase(ConnectPhase::ROAM_SCAN);
+}
+
+void WiFiManager::processRoamScanResults() {
+    int n = WiFi.scanComplete();
+    if (n < 0) {
+        LOG_WARN("WiFi roam scan: no results");
+        WiFi.scanDelete();
+        // Stay connected to current AP.
+        _connectPhase = ConnectPhase::CONNECTED;
+        return;
+    }
+
+    // Find the strongest visible AP that matches a configured SSID (any BSSID).
+    int8_t  bestRssi  = -127;
+    int     bestIdx   = -1;
+    uint8_t bestSlot  = 0xFF;
+    int cfgCount = _pendingConfig->getWifiNetworkCount();
+    for (int i = 0; i < n; i++) {
+        String visibleSsid = WiFi.SSID(i);
+        for (int slot = 0; slot < cfgCount; slot++) {
+            if (visibleSsid != _pendingConfig->getWifiSSID(slot)) continue;
+            int rssi = WiFi.RSSI(i);
+            if (rssi > bestRssi) {
+                bestRssi = (int8_t)rssi;
+                bestIdx  = i;
+                bestSlot = (uint8_t)slot;
+            }
+            break;
+        }
+    }
+
+    if (bestIdx < 0) {
+        LOG_WARN("WiFi roam scan: no known networks visible");
+        WiFi.scanDelete();
+        _connectPhase = ConnectPhase::CONNECTED;
+        return;
+    }
+
+    // Hysteresis check: only switch if the candidate beats current by margin.
+    int8_t currentRssi = (int8_t)WiFi.RSSI();
+    const uint8_t* currentBssid = WiFi.BSSID();
+    const uint8_t* candidateBssid = WiFi.BSSID(bestIdx);
+    bool sameAp = (currentBssid && candidateBssid &&
+                   memcmp(currentBssid, candidateBssid, 6) == 0);
+
+    if (sameAp) {
+        LOG_INFO("WiFi roam: best candidate is current AP - staying");
+        WiFi.scanDelete();
+        _connectPhase = ConnectPhase::CONNECTED;
+        return;
+    }
+
+    if (bestRssi < currentRssi + ROAM_HYSTERESIS_DB) {
+        LOGF("WiFi roam: candidate %d dBm vs current %d dBm (need >=%d delta) - staying",
+             bestRssi, currentRssi, ROAM_HYSTERESIS_DB);
+        WiFi.scanDelete();
+        _connectPhase = ConnectPhase::CONNECTED;
+        return;
+    }
+
+    LOGF("WiFi roam: switching to '%s' %d dBm (was %d dBm)",
+         _pendingConfig->getWifiSSID(bestSlot).c_str(), bestRssi, currentRssi);
+
+    // Build a single-candidate list pointing at the new AP, disconnect, and
+    // reuse the standard candidate-start machinery to (re)connect.
+    Candidate& c = _candidates[0];
+    c.configSlot = bestSlot;
+    if (candidateBssid) memcpy(c.bssid, candidateBssid, 6);
+    else                memset(c.bssid, 0, 6);
+    c.channel = (uint8_t)WiFi.channel(bestIdx);
+    c.rssi    = bestRssi;
+    _candidateCount   = 1;
+    _candidateIndex   = 0;
+    _candidateRetries = 0;
+
+    WiFi.scanDelete();
+    WiFi.disconnect(false);  // disconnect from current AP, keep STA up
+    delay(100);
+    startCurrentCandidate();
 }
 
 bool WiFiManager::isConnected() const { 

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -12,7 +12,8 @@ volatile uint8_t WiFiManager::_lastDisconnectReason = 0;
 WiFiManager::WiFiManager()
     : connected(false), mdnsStarted(false), apMode(false),
       _pendingTxPower(0), _hasPendingTxPower(false),
-      _connectPhase(ConnectPhase::IDLE), _phaseStartMs(0) {}
+      _connectPhase(ConnectPhase::IDLE), _phaseStartMs(0),
+      _consecutiveFailures(0) {}
 
 void WiFiManager::startAP() {
     LOG("Starting AP Mode (CPAP-AutoSync) for configuration");
@@ -222,12 +223,25 @@ void WiFiManager::terminateConnect(ConnectPhase result) {
     _phaseStartMs = millis();
     if (result == ConnectPhase::CONNECTED) {
         connected = true;
+        _consecutiveFailures = 0;
         LOG("WiFi connected");
         LOGF("IP address: %s", WiFi.localIP().toString().c_str());
     } else {
         connected = false;
+        if (_consecutiveFailures < 0xFF) _consecutiveFailures++;
         logConnectFailure();
+        LOGF("WiFi reconnect backoff: next attempt in %lu ms (failure #%u)",
+             (unsigned long)getReconnectIntervalMs(), (unsigned)_consecutiveFailures);
         Logger::getInstance().dumpSavedLogs("wifi_connection_failed");
+    }
+}
+
+uint32_t WiFiManager::getReconnectIntervalMs() const {
+    switch (_consecutiveFailures) {
+        case 0:  return  30 * 1000UL;
+        case 1:  return  60 * 1000UL;
+        case 2:  return 120 * 1000UL;
+        default: return 300 * 1000UL;  // capped at 5 min
     }
 }
 

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -12,6 +12,7 @@
 extern NetworkHints networkHints; // defined in main.cpp
 
 volatile uint8_t WiFiManager::_lastDisconnectReason = 0;
+volatile bool    WiFiManager::_hintRefreshPending  = false;
 
 WiFiManager::WiFiManager()
     : connected(false), mdnsStarted(false), apMode(false),
@@ -195,6 +196,9 @@ void WiFiManager::onWiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
             
         case ARDUINO_EVENT_WIFI_STA_GOT_IP:
             LOG_INFOF("WiFi Event: Got IP address: %s", WiFi.localIP().toString().c_str());
+            // Fires on every (re)association regardless of who initiated it
+            // pollConnect() consumes the flag and refreshes hint record for the current AP.
+            _hintRefreshPending = true;
             break;
             
         case ARDUINO_EVENT_WIFI_STA_LOST_IP:
@@ -254,6 +258,9 @@ void WiFiManager::terminateConnect(ConnectPhase result) {
                 }
             }
         }
+        // STA_GOT_IP also fires for this connect; consume the pending flag
+        // so pollConnect doesn't upsert a second time on the next tick.
+        _hintRefreshPending = false;
     } else {
         connected = false;
         if (_consecutiveFailures < 0xFF) _consecutiveFailures++;
@@ -281,6 +288,35 @@ void WiFiManager::logConnectFailure() {
         case WL_CONNECTION_LOST:LOG_ERROR("WiFi failure: Connection lost"); break;
         case WL_DISCONNECTED:   LOG_ERROR("WiFi failure: Disconnected"); break;
         default:                LOGF("WiFi failure: Unknown status %d", WiFi.status()); break;
+    }
+}
+
+// Update the NetworkHints record for the AP we are currently associated with.
+// The PMF flag is preserved from the existing hint since we don't have authoritative information about it in this path.
+void WiFiManager::refreshHintForCurrentConnection() {
+    if (!_pendingConfig || WiFi.status() != WL_CONNECTED) return;
+    String currentSsid = WiFi.SSID();
+    const uint8_t* bssid = WiFi.BSSID();
+    uint8_t channel = (uint8_t)WiFi.channel();
+    if (currentSsid.isEmpty() || !bssid || channel == 0) return;
+
+    // Find configured slot for current SSID; ignore if not in config.
+    int cfgCount = _pendingConfig->getWifiNetworkCount();
+    bool inConfig = false;
+    for (int slot = 0; slot < cfgCount; slot++) {
+        if (currentSsid == _pendingConfig->getWifiSSID(slot)) { inConfig = true; break; }
+    }
+    if (!inConfig) return;
+
+    // Preserve existing PMF flag if a hint already exists for this AP.
+    bool pmfDisable = false;
+    const SavedNetworkHint* existing = networkHints.find(currentSsid.c_str(), bssid);
+    if (existing) pmfDisable = (existing->pmf_disable != 0);
+
+    if (networkHints.upsert(currentSsid.c_str(), bssid, channel, pmfDisable)) {
+        networkHints.save();
+        LOG_DEBUGF("WiFi: hint refreshed for '%s' ch=%u (post-event)",
+                   currentSsid.c_str(), channel);
     }
 }
 
@@ -540,6 +576,10 @@ bool WiFiManager::beginConnect(const Config& cfg) {
 void WiFiManager::pollConnect() {
     // Roaming maintenance while connected.
     if (_connectPhase == ConnectPhase::CONNECTED) {
+        if (_hintRefreshPending) {
+            _hintRefreshPending = false;
+            refreshHintForCurrentConnection();
+        }
         roamingTick();
         return;
     }

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -249,7 +249,12 @@ bool WiFiManager::connectStation(const String& ssid, const String& password, con
 
     _lastDisconnectReason = 0;
     int attempts = 0;
-    while (WiFi.status() != WL_CONNECTED && attempts < 30) {
+    while (attempts < 30) {
+        wl_status_t status = WiFi.status();
+        if (status == WL_CONNECTED) break;
+        // Radio gave up - no point waiting the full timeout.
+        // The PMF retry path still runs if the disconnect reason warrants it.
+        if (status == WL_NO_SSID_AVAIL || status == WL_CONNECT_FAILED) break;
         delay(500);
         LOG_DEBUG(".");
         attempts++;
@@ -271,7 +276,10 @@ bool WiFiManager::connectStation(const String& ssid, const String& password, con
             esp_wifi_disconnect();
             esp_wifi_connect();
             attempts = 0;
-            while (WiFi.status() != WL_CONNECTED && attempts < 30) {
+            while (attempts < 30) {
+                wl_status_t status = WiFi.status();
+                if (status == WL_CONNECTED) break;
+                if (status == WL_NO_SSID_AVAIL || status == WL_CONNECT_FAILED) break;
                 delay(500);
                 LOG_DEBUG(".");
                 attempts++;

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -2,10 +2,14 @@
 #include "Logger.h"
 #include "Config.h"  // For power management enums
 #include "SDCardManager.h"
+#include "NetworkHints.h"
 #include <WiFi.h>
 #include <ESPmDNS.h>
 #include <esp_wifi.h>
 #include <esp_sntp.h>
+#include <time.h>
+
+extern NetworkHints networkHints; // defined in main.cpp
 
 volatile uint8_t WiFiManager::_lastDisconnectReason = 0;
 
@@ -15,7 +19,8 @@ WiFiManager::WiFiManager()
       _connectPhase(ConnectPhase::IDLE), _phaseStartMs(0),
       _consecutiveFailures(0),
       _candidateCount(0), _candidateIndex(0), _candidateRetries(0),
-      _pendingConfig(nullptr) {}
+      _pendingConfig(nullptr),
+      _pendingPmfDisable(false) {}
 
 void WiFiManager::startAP() {
     LOG("Starting AP Mode (CPAP-AutoSync) for configuration");
@@ -229,6 +234,24 @@ void WiFiManager::terminateConnect(ConnectPhase result) {
         _consecutiveFailures = 0;
         LOG("WiFi connected");
         LOGF("IP address: %s", WiFi.localIP().toString().c_str());
+
+        // Persist a hint for the AP we just connected to. WiFi.BSSID() and
+        // WiFi.channel() are authoritative now (the candidate's values may
+        // have been zero on the single-SSID direct path).
+        if (_pendingConfig && _candidateIndex < _candidateCount) {
+            uint8_t configSlot = _candidates[_candidateIndex].configSlot;
+            const String& ssid = _pendingConfig->getWifiSSID(configSlot);
+            const uint8_t* bssid = WiFi.BSSID();
+            uint8_t channel = (uint8_t)WiFi.channel();
+            if (bssid && channel > 0 && !ssid.isEmpty()) {
+                if (networkHints.upsert(ssid.c_str(), bssid, channel, _pendingPmfDisable)) {
+                    networkHints.save();
+                    LOGF("WiFi: hint saved for '%s' ch=%u%s",
+                         ssid.c_str(), channel,
+                         _pendingPmfDisable ? " (PMF disabled)" : "");
+                }
+            }
+        }
     } else {
         connected = false;
         if (_consecutiveFailures < 0xFF) _consecutiveFailures++;
@@ -271,6 +294,7 @@ void WiFiManager::enterPmfRetry() {
     esp_wifi_set_config(WIFI_IF_STA, &wifi_conf);
     esp_wifi_disconnect();
     esp_wifi_connect();
+    _pendingPmfDisable = true;
     enterPhase(ConnectPhase::PMF_RETRY);
 }
 
@@ -288,6 +312,26 @@ void WiFiManager::prepareSingleCandidate(uint8_t configSlot) {
     memset(_candidates[0].bssid, 0, 6);
     _candidates[0].channel = 0;
     _candidates[0].rssi    = 0;
+
+   // Single-SSID path: no scan to source a BSSID/channel from. Try to find
+   // a hint for this SSID (any BSSID; pick the most recently used) so we can
+   // skip the radio's own scan during association.
+   if (_pendingConfig) {
+       const String& ssid = _pendingConfig->getWifiSSID(configSlot);
+       const SavedNetworkHint* best = nullptr;
+       for (int i = 0; i < networkHints.count(); i++) {
+           const SavedNetworkHint* h = networkHints.at(i);
+           if (h && strcmp(h->ssid, ssid.c_str()) == 0) {
+               if (!best || h->last_used_secs > best->last_used_secs) best = h;
+           }
+       }
+       if (best) {
+           memcpy(_candidates[0].bssid, best->bssid, 6);
+           _candidates[0].channel = best->channel;
+           LOGF("WiFi: using cached hint for '%s' (ch=%u)", ssid.c_str(), best->channel);
+       }
+   }
+
     _candidateCount   = 1;
     _candidateIndex   = 0;
     _candidateRetries = 0;
@@ -370,6 +414,19 @@ bool WiFiManager::startCurrentCandidate() {
     _pendingPassword = _pendingConfig->getWifiPassword(c.configSlot);
     _lastDisconnectReason = 0;
 
+    // Look up persisted hint for this exact (ssid, bssid). Used to pre-set the
+    // PMF-disable flag on routers we already know reject 802.11w
+    _pendingPmfDisable = false;
+    bool hasBssid = (c.bssid[0] | c.bssid[1] | c.bssid[2] |
+                     c.bssid[3] | c.bssid[4] | c.bssid[5]) != 0;
+    if (hasBssid) {
+        const SavedNetworkHint* hint = networkHints.find(_pendingSsid.c_str(), c.bssid);
+        if (hint && hint->pmf_disable) {
+            _pendingPmfDisable = true;
+            LOGF("WiFi: hint says PMF disabled for '%s'", _pendingSsid.c_str());
+        }
+    }
+
     bool hasHint = (c.channel > 0);
     if (hasHint) {
         LOGF("WiFi: connecting to '%s' (ch=%u, RSSI %d dBm)",
@@ -378,6 +435,22 @@ bool WiFiManager::startCurrentCandidate() {
     } else {
         LOGF("WiFi: connecting to '%s'", _pendingSsid.c_str());
         WiFi.begin(_pendingSsid.c_str(), _pendingPassword.c_str());
+    }
+
+    // If we already know this AP needs PMF disabled, override the default
+    // (capable=true) configuration immediately. WiFi.begin() set the SSID/pass
+    // via esp_wifi_set_config; we override pmf_cfg and reconnect, course-
+    // correcting the in-flight association before it has a chance to fail
+    // with reason 208.
+    if (_pendingPmfDisable) {
+        wifi_config_t wifi_conf;
+        if (esp_wifi_get_config(WIFI_IF_STA, &wifi_conf) == ESP_OK) {
+            wifi_conf.sta.pmf_cfg.capable  = false;
+            wifi_conf.sta.pmf_cfg.required = false;
+            esp_wifi_set_config(WIFI_IF_STA, &wifi_conf);
+            esp_wifi_disconnect();
+            esp_wifi_connect();
+        }
     }
 
     // Apply deferred TX power AFTER WiFi.begin() — WiFi.mode(WIFI_STA) is async

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,11 +60,14 @@ bool g_mdnsTimedOut = false;
 // ============================================================================
 // Global Objects
 // ============================================================================
+#include "NetworkHints.h"
+
 Config config;
 SDCardManager sdManager;
 WiFiManager wifiManager;
 FileUploader* uploader = nullptr;
 TrafficMonitor trafficMonitor;
+NetworkHints networkHints;
 
 #ifdef ENABLE_OTA_UPDATES
 OTAManager otaManager;
@@ -727,6 +730,9 @@ void setup() {
 
     // Setup WiFi event handlers for logging
     wifiManager.setupEventHandlers();
+
+    // Load cached per-AP connection hints (BSSID, channel, PMF flag) from NVS.
+    networkHints.begin();
 
     // Defer TX power cap — applied inside connectStation() after WiFi.mode(WIFI_STA)
     // to avoid "Neither AP or STA has been started" warning.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1805,7 +1805,11 @@ void loop() {
         }
     } else if (!g_apSetupMode && !wifiManager.isConnected() && !uploadTaskRunning) {
         unsigned long currentTime = millis();
-        if (currentTime - lastWifiReconnectAttempt >= wifiManager.getReconnectIntervalMs()) {
+        bool intervalElapsed = (currentTime - lastWifiReconnectAttempt >= wifiManager.getReconnectIntervalMs());
+        // PCNT-aware bus-idle gate: defer the RF burst if the CPAP is currently using the SD bus
+        // No-op on non-pcnt capable devices
+        bool busBusy = g_pcntCapable && !trafficMonitor.isIdleFor(2000);
+        if (intervalElapsed && !busBusy) {
             LOG_WARN("WiFi disconnected, attempting to reconnect...");
 
             if (!config.valid() || config.getWifiSSID().isEmpty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1792,14 +1792,19 @@ void loop() {
     // GUARD: Skip when in AP setup mode. beginConnect() uses WIFI_AP_STA
     // when apMode is true (so a retry would not disrupt the AP), but the
     // current UX intent is "user is configuring, stop retrying old creds".
+    // Tracks whether the new-attempt block below relaxed brownout detection
+    // for the in-flight attempt. Roam scans don't relax brownout, so we must
+    // not re-enable it (or log "reconnect complete") when a roam-stay decision
+    // exits ROAM_SCAN -> CONNECTED.
+    static bool brownoutRelaxedThisAttempt = false;
+
     bool wasInProgress = wifiManager.isConnectInProgress();
     wifiManager.pollConnect();
     if (wasInProgress && !wifiManager.isConnectInProgress()) {
-        // Just terminated a connect attempt this tick - re-enable brownout
-        // detection if relaxed.
-        if (config.getBrownoutDetectMode() == BrownoutDetectMode::RELAXED) {
+        if (brownoutRelaxedThisAttempt) {
             LOG_INFO("[POWER] WiFi reconnect complete - re-enabling brownout detection");
             SET_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
+            brownoutRelaxedThisAttempt = false;
         }
         if (wifiManager.getConnectPhase() == WiFiManager::ConnectPhase::CONNECTED) {
             LOG_DEBUG("WiFi reconnected successfully");
@@ -1826,6 +1831,7 @@ void loop() {
             if (config.getBrownoutDetectMode() == BrownoutDetectMode::RELAXED) {
                 LOG_INFO("[POWER] Relaxing brownout detection for WiFi reconnect");
                 CLEAR_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
+                brownoutRelaxedThisAttempt = true;
             }
 
             wifiManager.beginConnect(config);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1805,7 +1805,7 @@ void loop() {
         }
     } else if (!g_apSetupMode && !wifiManager.isConnected() && !uploadTaskRunning) {
         unsigned long currentTime = millis();
-        if (currentTime - lastWifiReconnectAttempt >= 30000) {
+        if (currentTime - lastWifiReconnectAttempt >= wifiManager.getReconnectIntervalMs()) {
             LOG_WARN("WiFi disconnected, attempting to reconnect...");
 
             if (!config.valid() || config.getWifiSSID().isEmpty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1780,47 +1780,47 @@ void loop() {
         stopMonitoringRequested = true;
     }
 #endif
-    
+
     // ── WiFi reconnection (non-blocking with 30 second retry interval) ──
     // GUARD: Do NOT attempt reconnection while upload task is running on Core 0.
     // The upload task manages its own WiFi recovery via tryCoordinatedWifiCycle().
     // Concurrent reconnection from both cores corrupts the lwIP state machine.
-    // GUARD: Do NOT reconnect in AP setup mode — the radio is intentionally in
-    // WIFI_AP and calling connectStation() would tear down the AP broadcast.
-    if (!g_apSetupMode && !wifiManager.isConnected() && !uploadTaskRunning) {
+    // GUARD: Skip when in AP setup mode. beginConnect() uses WIFI_AP_STA
+    // when apMode is true (so a retry would not disrupt the AP), but the
+    // current UX intent is "user is configuring, stop retrying old creds".
+    // TODO: revisit: backoff schedule + whether STA should keep
+    // retrying in AP mode for self-healing on transient outages.
+    if (wifiManager.isConnectInProgress()) {
+        wifiManager.pollConnect();
+        if (!wifiManager.isConnectInProgress()) {
+            // Just terminated this tick - re-enable brownout detection if relaxed.
+            if (config.getBrownoutDetectMode() == BrownoutDetectMode::RELAXED) {
+                LOG_INFO("[POWER] WiFi reconnect complete - re-enabling brownout detection");
+                SET_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
+            }
+            if (wifiManager.getConnectPhase() == WiFiManager::ConnectPhase::CONNECTED) {
+                LOG_DEBUG("WiFi reconnected successfully");
+            }
+            // FAILED case logs inside terminateConnect via logConnectFailure().
+        }
+    } else if (!g_apSetupMode && !wifiManager.isConnected() && !uploadTaskRunning) {
         unsigned long currentTime = millis();
         if (currentTime - lastWifiReconnectAttempt >= 30000) {
             LOG_WARN("WiFi disconnected, attempting to reconnect...");
-            
+
             if (!config.valid() || config.getWifiSSID().isEmpty()) {
                 LOG_ERROR("Cannot reconnect to WiFi: Invalid configuration");
                 lastWifiReconnectAttempt = currentTime;
                 return;
             }
-            
-            // ── POWER: Relax brownout detection before reconnecting ──
+
             if (config.getBrownoutDetectMode() == BrownoutDetectMode::RELAXED) {
                 LOG_INFO("[POWER] Relaxing brownout detection for WiFi reconnect");
                 CLEAR_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
             }
-            
-            if (!wifiManager.connectStation(config.getWifiSSID(), config.getWifiPassword(), config.getHostname())) {
-                LOG_ERROR("Failed to reconnect to WiFi");
-                lastWifiReconnectAttempt = currentTime;
-                
-                // Re-enable if we failed early
-                if (config.getBrownoutDetectMode() == BrownoutDetectMode::RELAXED) {
-                    SET_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
-                }
-                return;
-            }
-            LOG_DEBUG("WiFi reconnected successfully");
-            
-            // Re-enable brownout detection after a successful reconnect attempt.
-            if (config.getBrownoutDetectMode() == BrownoutDetectMode::RELAXED) {
-                LOG_INFO("[POWER] WiFi reconnect complete — re-enabling brownout detection");
-                SET_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
-            }
+
+            wifiManager.beginConnect(config.getWifiSSID(), config.getWifiPassword(), config.getHostname());
+            lastWifiReconnectAttempt = currentTime;  // count from attempt start
         }
 
         // Initialize web server regardless of connection success

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1789,11 +1789,11 @@ void loop() {
     // GUARD: Do NOT attempt reconnection while upload task is running on Core 0.
     // The upload task manages its own WiFi recovery via tryCoordinatedWifiCycle().
     // Concurrent reconnection from both cores corrupts the lwIP state machine.
-    // GUARD: Skip when in AP setup mode. beginConnect() uses WIFI_AP_STA
-    // when apMode is true (so a retry would not disrupt the AP), but the
-    // current UX intent is "user is configuring, stop retrying old creds".
+    // While in boot-fallback AP mode we keep retrying in the background so the
+    // device can self-heal once the router comes back, but skip the retry while
+    // an AP client is connected (user is mid-config; don't disrupt the radio).
     // Tracks whether the new-attempt block below relaxed brownout detection
-    // for the in-flight attempt. Roam scans don't relax brownout, so we must
+    // for the in-flight attempt.  Roam scans don't relax brownout, so we must
     // not re-enable it (or log "reconnect complete") when a roam-stay decision
     // exits ROAM_SCAN -> CONNECTED.
     static bool brownoutRelaxedThisAttempt = false;
@@ -1813,7 +1813,8 @@ void loop() {
     }
 
     if (!wifiManager.isConnectInProgress() &&
-        !g_apSetupMode && !wifiManager.isConnected() && !uploadTaskRunning) {
+        !wifiManager.isConnected() && !uploadTaskRunning &&
+        wifiManager.getApClientCount() == 0) {
         unsigned long currentTime = millis();
         bool intervalElapsed = (currentTime - lastWifiReconnectAttempt >= wifiManager.getReconnectIntervalMs());
         // PCNT-aware bus-idle gate: defer the RF burst if the CPAP is currently using the SD bus
@@ -1840,6 +1841,20 @@ void loop() {
 
         // Initialize web server regardless of connection success
         // It will either serve normal UI or AP setup UIFSM while WiFi is down
+    }
+
+    // Stable-quiet AP teardown
+    // If we booted into AP-fallback (failed STA at boot) and STA has since
+    // recovered, drop the AP back down so the radio runs in plain STA again.
+    // We reboot rather than tearing down in place: the AP-mode boot path
+    // skipped uploader/scheduler init, so a clean reboot through the normal
+    // STA path is the simplest way to bring the device fully online.
+    if (g_apSetupMode && wifiManager.shouldTearDownAP()) {
+        LOG_INFO("[AP] STA reconnected stably for 2 min, no AP clients - rebooting to exit AP mode");
+        setRebootReason("AP fallback teardown after STA recovery");
+        Logger::getInstance().flushBeforeReboot();
+        delay(300);
+        esp_restart();
     }
 
     // ── NTP sync retry ──

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1381,7 +1381,8 @@ void handleUploading() {
         
         uploadTaskComplete = false;
         uploadTaskRunning = true;
-        
+        wifiManager.suspendRoaming();  // no roam scans / AP switches mid-upload
+
         // Relax task watchdog during upload — TLS handshake (5-15s of CPU-intensive
         // crypto) starves IDLE0 on Core 0. Instead of removing IDLE0 from monitoring
         // (which causes "task not found" error spam because IDLE0 still calls
@@ -1415,6 +1416,7 @@ void handleUploading() {
                        ESP.getFreeHeap(),
                        ESP.getMaxAllocHeap());
             uploadTaskRunning = false;
+            wifiManager.resumeRoaming();
             delete params;
             // Restore normal watchdog timeout (task creation failed)
             {
@@ -1436,6 +1438,7 @@ void handleUploading() {
     } else if (uploadTaskComplete) {
         // ── Task finished: read result and transition ──
         uploadTaskRunning = false;
+        wifiManager.resumeRoaming();
         uploadTaskHandle = nullptr;
         g_abortUploadFlag = false;  // Clear abort flag — task has stopped
         
@@ -1738,6 +1741,7 @@ void loop() {
             LOG_WARN("[FSM] Killing active upload task for state reset");
             vTaskDelete(uploadTaskHandle);
             uploadTaskRunning = false;
+            wifiManager.resumeRoaming();
             uploadTaskHandle = nullptr;
         }
         
@@ -1788,22 +1792,23 @@ void loop() {
     // GUARD: Skip when in AP setup mode. beginConnect() uses WIFI_AP_STA
     // when apMode is true (so a retry would not disrupt the AP), but the
     // current UX intent is "user is configuring, stop retrying old creds".
-    // TODO: revisit: backoff schedule + whether STA should keep
-    // retrying in AP mode for self-healing on transient outages.
-    if (wifiManager.isConnectInProgress()) {
-        wifiManager.pollConnect();
-        if (!wifiManager.isConnectInProgress()) {
-            // Just terminated this tick - re-enable brownout detection if relaxed.
-            if (config.getBrownoutDetectMode() == BrownoutDetectMode::RELAXED) {
-                LOG_INFO("[POWER] WiFi reconnect complete - re-enabling brownout detection");
-                SET_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
-            }
-            if (wifiManager.getConnectPhase() == WiFiManager::ConnectPhase::CONNECTED) {
-                LOG_DEBUG("WiFi reconnected successfully");
-            }
-            // FAILED case logs inside terminateConnect via logConnectFailure().
+    bool wasInProgress = wifiManager.isConnectInProgress();
+    wifiManager.pollConnect();
+    if (wasInProgress && !wifiManager.isConnectInProgress()) {
+        // Just terminated a connect attempt this tick - re-enable brownout
+        // detection if relaxed.
+        if (config.getBrownoutDetectMode() == BrownoutDetectMode::RELAXED) {
+            LOG_INFO("[POWER] WiFi reconnect complete - re-enabling brownout detection");
+            SET_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
         }
-    } else if (!g_apSetupMode && !wifiManager.isConnected() && !uploadTaskRunning) {
+        if (wifiManager.getConnectPhase() == WiFiManager::ConnectPhase::CONNECTED) {
+            LOG_DEBUG("WiFi reconnected successfully");
+        }
+        // FAILED case logs inside terminateConnect via logConnectFailure().
+    }
+
+    if (!wifiManager.isConnectInProgress() &&
+        !g_apSetupMode && !wifiManager.isConnected() && !uploadTaskRunning) {
         unsigned long currentTime = millis();
         bool intervalElapsed = (currentTime - lastWifiReconnectAttempt >= wifiManager.getReconnectIntervalMs());
         // PCNT-aware bus-idle gate: defer the RF burst if the CPAP is currently using the SD bus

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -755,9 +755,17 @@ void setup() {
             LOG_ERROR("Failed to connect to WiFi after 2 attempts.");
 
             // ── EMERGENCY BOOT ERROR DUMP ──
-            if (sdManager.takeControl()) {
-                Logger::getInstance().dumpToSD(sdManager.getFS(), "/uploader_error.txt", "WiFi connection failure");
-                sdManager.releaseControl();
+            // The WiFi attempts above ran a ~30s busy-wait that froze the main
+            // loop, so the PCNT idle counter is stale. Refresh it before gating.
+            trafficMonitor.update();
+            bool safeToDump = !g_pcntCapable || trafficMonitor.isIdleFor(2000);
+            if (safeToDump) {
+                if (sdManager.takeControl()) {
+                    Logger::getInstance().dumpToSD(sdManager.getFS(), "/uploader_error.txt", "WiFi connection failure");
+                    sdManager.releaseControl();
+                }
+            } else {
+                LOG_WARN("[Boot] CPAP bus active — skipping SD log dump to avoid mid-transaction MUX flip");
             }
 
             // Re-enable brownout detection if it was only relaxed for boot

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -749,12 +749,12 @@ void setup() {
         }
     } else {
         // Attempt 1
-        bool connected = wifiManager.connectStation(config.getWifiSSID(), config.getWifiPassword(), config.getHostname());
+        bool connected = wifiManager.connectStation(config);
         if (!connected) {
             LOG_WARN("WiFi connect attempt 1 failed — waiting 3s before retry...");
             delay(3000);
             // Attempt 2
-            connected = wifiManager.connectStation(config.getWifiSSID(), config.getWifiPassword(), config.getHostname());
+            connected = wifiManager.connectStation(config);
         }
 
         if (!connected) {
@@ -1819,7 +1819,7 @@ void loop() {
                 CLEAR_PERI_REG_MASK(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ENA);
             }
 
-            wifiManager.beginConnect(config.getWifiSSID(), config.getWifiPassword(), config.getHostname());
+            wifiManager.beginConnect(config);
             lastWifiReconnectAttempt = currentTime;  // count from attempt start
         }
 

--- a/src/web/setup.html
+++ b/src/web/setup.html
@@ -308,6 +308,12 @@
         <!-- ════════ WiFi ════════ -->
         <div class="card">
             <h2>WiFi Connection</h2>
+            <p class="help-text" style="margin-top:0">
+                Configure up to 4 networks. The device connects to the strongest available one
+                and roams between them as signal degrades.
+            </p>
+
+            <!-- Primary network (slot 1) -->
             <div class="fg">
                 <label for="f-ssid">Network Name (SSID)</label>
                 <div style="display:flex;gap:8px;align-items:flex-start">
@@ -325,6 +331,64 @@
                     <button type="button" class="eye-btn" onclick="togglePwd(this)" title="Show/hide password">&#128065;</button>
                 </div>
             </div>
+
+            <!-- Secondary networks (slots 2-4) — hidden by default -->
+            <div class="wifi-network-extra hidden" id="wifi-row-2">
+                <hr style="border-color:#2a2f3a;margin:14px 0">
+                <div class="fg">
+                    <label for="f-ssid-2">Network 2 SSID</label>
+                    <div style="display:flex;gap:8px;align-items:flex-start">
+                        <input type="text" id="f-ssid-2" placeholder="Secondary network name" style="flex:1">
+                        <button type="button" class="btn bs" onclick="removeNetwork(2)">Remove</button>
+                    </div>
+                </div>
+                <div class="fg">
+                    <label for="f-wifipass-2">Network 2 Password</label>
+                    <div class="pwd-wrap">
+                        <input type="password" id="f-wifipass-2" placeholder="Leave blank to keep existing">
+                        <button type="button" class="eye-btn" onclick="togglePwd(this)" title="Show/hide password">&#128065;</button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="wifi-network-extra hidden" id="wifi-row-3">
+                <hr style="border-color:#2a2f3a;margin:14px 0">
+                <div class="fg">
+                    <label for="f-ssid-3">Network 3 SSID</label>
+                    <div style="display:flex;gap:8px;align-items:flex-start">
+                        <input type="text" id="f-ssid-3" placeholder="Tertiary network name" style="flex:1">
+                        <button type="button" class="btn bs" onclick="removeNetwork(3)">Remove</button>
+                    </div>
+                </div>
+                <div class="fg">
+                    <label for="f-wifipass-3">Network 3 Password</label>
+                    <div class="pwd-wrap">
+                        <input type="password" id="f-wifipass-3" placeholder="Leave blank to keep existing">
+                        <button type="button" class="eye-btn" onclick="togglePwd(this)" title="Show/hide password">&#128065;</button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="wifi-network-extra hidden" id="wifi-row-4">
+                <hr style="border-color:#2a2f3a;margin:14px 0">
+                <div class="fg">
+                    <label for="f-ssid-4">Network 4 SSID</label>
+                    <div style="display:flex;gap:8px;align-items:flex-start">
+                        <input type="text" id="f-ssid-4" placeholder="Quaternary network name" style="flex:1">
+                        <button type="button" class="btn bs" onclick="removeNetwork(4)">Remove</button>
+                    </div>
+                </div>
+                <div class="fg">
+                    <label for="f-wifipass-4">Network 4 Password</label>
+                    <div class="pwd-wrap">
+                        <input type="password" id="f-wifipass-4" placeholder="Leave blank to keep existing">
+                        <button type="button" class="eye-btn" onclick="togglePwd(this)" title="Show/hide password">&#128065;</button>
+                    </div>
+                </div>
+            </div>
+
+            <button type="button" class="btn bs" id="btn-add-network" onclick="addNetwork()"
+                    style="margin-top:12px">+ Add another network</button>
         </div>
 
         <!-- ════════ Timezone ════════ -->
@@ -588,7 +652,10 @@
 
 // Keys managed by the visual form (everything else is preserved as-is)
 var KNOWN_KEYS = [
-    'WIFI_SSID', 'WIFI_PASSWORD', 'HOSTNAME',
+    'WIFI_SSID', 'WIFI_PASSWORD',
+    'WIFI_SSID_1', 'WIFI_SSID_2', 'WIFI_SSID_3', 'WIFI_SSID_4',
+    'WIFI_PASSWORD_1', 'WIFI_PASSWORD_2', 'WIFI_PASSWORD_3', 'WIFI_PASSWORD_4',
+    'HOSTNAME',
     'TZ_STRING', 'TZ_NAME',
     'UPLOAD_MODE', 'UPLOAD_START_HOUR', 'UPLOAD_END_HOUR', 'SMART_START_HOUR', 'COOLDOWN_MINUTES', 'EXCLUSIVE_ACCESS_MINUTES',
     'ENDPOINT_TYPE', 'ENDPOINT', 'ENDPOINT_USER', 'ENDPOINT_PASSWORD',
@@ -596,7 +663,11 @@ var KNOWN_KEYS = [
 ];
 
 // Password keys — values from the server arrive as '******'
-var PASSWORD_KEYS = ['WIFI_PASSWORD', 'ENDPOINT_PASSWORD', 'CLOUD_CLIENT_SECRET'];
+var PASSWORD_KEYS = [
+    'WIFI_PASSWORD',
+    'WIFI_PASSWORD_1', 'WIFI_PASSWORD_2', 'WIFI_PASSWORD_3', 'WIFI_PASSWORD_4',
+    'ENDPOINT_PASSWORD', 'CLOUD_CLIENT_SECRET'
+];
 
 var rawLines = [];   // Array of { type:'kv'|'comment'|'blank'|'raw', key:'', val:'', raw:'' }
 var timezones = [];  // Array of { name:'', posix:'' }
@@ -684,9 +755,19 @@ function getValue(key) {
 // ══════════════════════════════════════════════════════════════
 
 function populateFormFromConfig() {
-    // WiFi
-    document.getElementById('f-ssid').value = getValue('WIFI_SSID');
-    // Password fields are left empty — '******' from server is intentionally not shown
+    // WiFi - slot 1: prefer WIFI_SSID_1, fall back to WIFI_SSID alias.
+    document.getElementById('f-ssid').value = getValue('WIFI_SSID_1') || getValue('WIFI_SSID');
+
+    // Slots 2-4: load if present, reveal the row.
+    for (var n = 2; n <= 4; n++) {
+        var ssid = getValue('WIFI_SSID_' + n);
+        document.getElementById('f-ssid-' + n).value = ssid;
+        if (ssid) {
+            document.getElementById('wifi-row-' + n).classList.remove('hidden');
+        }
+    }
+    updateAddNetworkButton();
+    // Password fields are left empty - '******' from server is intentionally not shown
 
     // Timezone — prefer TZ_NAME (IANA name) over POSIX reverse-lookup
     document.getElementById('f-tz-value').value = getValue('TZ_STRING');
@@ -941,6 +1022,48 @@ function togglePwd(btn) {
 }
 
 // ══════════════════════════════════════════════════════════════
+// Multi-network add / remove
+// ══════════════════════════════════════════════════════════════
+
+function addNetwork() {
+    // Show the lowest-numbered hidden slot (2..4).
+    for (var n = 2; n <= 4; n++) {
+        var row = document.getElementById('wifi-row-' + n);
+        if (row.classList.contains('hidden')) {
+            row.classList.remove('hidden');
+            document.getElementById('f-ssid-' + n).focus();
+            break;
+        }
+    }
+    updateAddNetworkButton();
+    updateRawPreview();
+}
+
+function removeNetwork(slot) {
+    var row = document.getElementById('wifi-row-' + slot);
+    if (!row) return;
+    document.getElementById('f-ssid-' + slot).value = '';
+    document.getElementById('f-wifipass-' + slot).value = '';
+    row.classList.add('hidden');
+    updateAddNetworkButton();
+    updateRawPreview();
+}
+
+function updateAddNetworkButton() {
+    var btn = document.getElementById('btn-add-network');
+    if (!btn) return;
+    // Hide the button when all 4 rows are visible.
+    var allVisible = true;
+    for (var n = 2; n <= 4; n++) {
+        if (document.getElementById('wifi-row-' + n).classList.contains('hidden')) {
+            allVisible = false;
+            break;
+        }
+    }
+    btn.classList.toggle('hidden', allVisible);
+}
+
+// ══════════════════════════════════════════════════════════════
 // PCNT capability (Smart Mode availability)
 // ══════════════════════════════════════════════════════════════
 function applyPcntCapable(capable) {
@@ -1152,14 +1275,34 @@ function toggleRaw() {
 function collectFormValues() {
     var vals = {};
 
+    // Slot 1 - keep using WIFI_SSID / WIFI_PASSWORD (alias for slot 1) so
+    // existing single-network configs round-trip without reformatting.
     vals['WIFI_SSID'] = document.getElementById('f-ssid').value.trim();
-
-    // WiFi password: blank = keep existing (server restores from masked value)
     var wifiPass = document.getElementById('f-wifipass').value;
     if (wifiPass !== '') {
         vals['WIFI_PASSWORD'] = wifiPass;
     }
     // else: key not in vals → rawLines keeps original '******'
+
+    // Slots 2-4: write WIFI_SSID_N / WIFI_PASSWORD_N when SSID is non-empty.
+    // If a slot was previously populated and is now empty, write empty SSID
+    // so the parser drops the entry on next load (compaction in Config).
+    for (var n = 2; n <= 4; n++) {
+        var rowVisible = !document.getElementById('wifi-row-' + n).classList.contains('hidden');
+        var ssid = document.getElementById('f-ssid-' + n).value.trim();
+        var pwd  = document.getElementById('f-wifipass-' + n).value;
+        if (rowVisible && ssid) {
+            vals['WIFI_SSID_' + n] = ssid;
+            if (pwd !== '') vals['WIFI_PASSWORD_' + n] = pwd;
+        } else {
+            // Row hidden or SSID cleared - emit empty so any pre-existing
+            // entry in config.txt is overwritten with blank (treated as unset).
+            vals['WIFI_SSID_' + n] = '';
+            if (pwd !== '') {
+                vals['WIFI_PASSWORD_' + n] = '';
+            }
+        }
+    }
 
     // Timezone — write both TZ_STRING (POSIX) and TZ_NAME (IANA) to config
     if (!document.getElementById('tz-select-wrap').classList.contains('hidden')) {


### PR DESCRIPTION
follow up to #97 

Adds support for up to 4 configured WiFi networks with automatic
roaming, per-AP connection-hint caching, exponential reconnect backoff,
and a non-blocking begin/poll connect API.  Replaces the previous
single-SSID synchronous reconnect path that froze the FSM for 15 s on
every failed attempt.

- **Up to 4 WiFi networks**: `WIFI_SSID_1..4` / `WIFI_PASSWORD_1..4` in `config.txt`
  `WIFI_SSID` / `WIFI_PASSWORD` are aliases for slot 1 for back-compat.
- **Roaming** when 2+ networks are configured. Periodic RSSI sample (60 s)
  below -73 dBm for 3 consecutive samples triggers a scan; switches APs when a
  candidate beats current by >=8 dB hysteresis;
- **Faster reconnects** via cached BSSID + channel + PMF flag per AP
- **Exponential backoff** for failed reconnects: 30s -> 60s -> 2m -> 5m. Reset on success.
  Significantly reduces RF burst frequency in environments with no available network.
- **PCNT-aware bus-idle gate** defers reconnect attempts while the CPAP is using the SD bus

Not implemented yet:
- ~Setup wizard UI for multi-SSID~
- ~STA reconnects in softAP fallback mode - `beginConnect()` is already plumbed to use 
  `WIFI_AP_STA` instead of plain `WIFI_STA` when a softAP is up, so the radio coexistence is in place,
  but nothing currently invokes it~
