### PR TITLE
feat: minify and gzip both web payloads, reclaim ~53 KB flash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ compile_commands.json
 # Auto-generated files
 include/version.h
 include/setup_html_gz.h
+include/web_ui_gz.h
 
 # Temporary files
 *.tmp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 platformio>=6.1.0
 esptool>=4.6.0
+minify-html>=0.15

--- a/scripts/generate_html_gz.py
+++ b/scripts/generate_html_gz.py
@@ -6,6 +6,96 @@ except NameError:
 import gzip
 import os
 import json
+import re
+import sys
+import glob
+
+
+# minify-html installed into ./venv by setup.sh, but pio runs scripts under
+# its own Python interpreter. add the project venv's site-packages to sys.path
+def _add_project_venv_to_path():
+    candidates = (
+        glob.glob("venv/lib/python*/site-packages")
+        + glob.glob("venv/Lib/site-packages")
+    )
+    for sp in candidates:
+        absp = os.path.abspath(sp)
+        if absp not in sys.path:
+            sys.path.insert(0, absp)
+
+
+_add_project_venv_to_path()
+
+try:
+    import minify_html as _mhtml
+    _HAVE_MINIFY_HTML = True
+except ImportError:
+    _HAVE_MINIFY_HTML = False
+
+
+# Fallback minifier: tag-aware, no deps
+# rules per region:
+#   outside  : strip <!-- --> comments, collapse whitespace runs, strip
+#              whitespace between adjacent tags
+#   <style>  : strip /* */ comments, collapse whitespace
+#   <script> : strip /* */ comments only (whitespace/line-comments left alone
+#              to avoid breaking ASI or comment-tokens nested in strings/regex)
+#   <pre>, <textarea>: untouched (whitespace is semantically meaningful)
+
+_PROTECTED_RE = re.compile(
+    r"(<script\b[^>]*>.*?</script>|<style\b[^>]*>.*?</style>|"
+    r"<pre\b[^>]*>.*?</pre>|<textarea\b[^>]*>.*?</textarea>)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _fallback_minify_outside(s):
+    s = re.sub(r"<!--.*?-->", "", s, flags=re.DOTALL)
+    s = re.sub(r"\s+", " ", s)
+    s = re.sub(r">\s+<", "><", s)
+    return s
+
+
+def _fallback_minify_style(s):
+    head, _, body = s.partition(">")
+    body, _, tail = body.rpartition("</style>")
+    body = re.sub(r"/\*.*?\*/", "", body, flags=re.DOTALL)
+    body = re.sub(r"\s+", " ", body).strip()
+    return head + ">" + body + "</style>" + tail
+
+
+def _fallback_minify_script(s):
+    head, _, body = s.partition(">")
+    body, _, tail = body.rpartition("</script>")
+    body = re.sub(r"/\*.*?\*/", "", body, flags=re.DOTALL)
+    return head + ">" + body + "</script>" + tail
+
+
+def _fallback_minify_html(html):
+    parts = _PROTECTED_RE.split(html)
+    out = []
+    for p in parts:
+        low = p[:9].lower()
+        if low.startswith("<script"):
+            out.append(_fallback_minify_script(p))
+        elif low.startswith("<style"):
+            out.append(_fallback_minify_style(p))
+        elif low.startswith("<pre") or low.startswith("<textarea"):
+            out.append(p)
+        else:
+            out.append(_fallback_minify_outside(p))
+    return "".join(out)
+
+
+def minify_html(html):
+    if _HAVE_MINIFY_HTML:
+        return _mhtml.minify(
+            html,
+            minify_css=True,
+            minify_js=True,
+            keep_html_and_head_opening_tags=True,
+        )
+    return _fallback_minify_html(html)
 
 
 def fetch_timezone_data():
@@ -35,46 +125,80 @@ def fetch_timezone_data():
         return "{}"
 
 
-def generate_header(*args, **kwargs):
-    print("Generating compressed HTML payload...")
-    input_file = "src/web/setup.html"
-    output_file = "include/setup_html_gz.h"
+def _write_empty_header(output_file, symbol):
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    with open(output_file, 'w') as f:
+        f.write("#pragma once\n")
+        f.write(f"const uint8_t {symbol}[] = {{0}};\n")
+        f.write(f"const size_t {symbol}_len = 0;\n")
 
+
+def _write_gz_header(output_file, symbol, input_file, payload):
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    with open(output_file, 'w') as f:
+        f.write("#pragma once\n\n")
+        f.write(f"// Generated from {input_file}\n")
+        f.write(f"const uint8_t {symbol}[] = {{\n")
+        hex_array = [f"0x{b:02x}" for b in payload]
+        for i in range(0, len(hex_array), 16):
+            f.write("    " + ", ".join(hex_array[i:i+16]) + ",\n")
+        f.write("};\n\n")
+        f.write(f"const size_t {symbol}_len = {len(payload)};\n")
+
+
+def _process_html(input_file, output_file, symbol, inject_tz=False):
+    """Read HTML, optionally inject TZ data, minify, gzip, emit C header."""
     if not os.path.exists(input_file):
-        print(f"Warning: {input_file} not found. Creating empty file to prevent build errors.")
-        os.makedirs(os.path.dirname(output_file), exist_ok=True)
-        with open(output_file, 'w') as f:
-            f.write("#pragma once\nconst uint8_t setup_html_gz[] = {0};\nconst size_t setup_html_gz_len = 0;\n")
+        print(f"  Warning: {input_file} not found - emitting empty {symbol}.")
+        _write_empty_header(output_file, symbol)
         return
 
     with open(input_file, 'r', encoding='utf-8') as f:
         html_content = f.read()
 
-    # Embed timezone data at build time (replaces the placeholder in setup.html)
-    tz_placeholder = "/*__TIMEZONE_DATA__*/{}"
-    if tz_placeholder in html_content:
-        tz_data = fetch_timezone_data()
-        html_content = html_content.replace(tz_placeholder, tz_data)
-        print(f"  Timezone data injected ({len(tz_data)} chars).")
+    if inject_tz:
+        tz_placeholder = "/*__TIMEZONE_DATA__*/{}"
+        if tz_placeholder in html_content:
+            tz_data = fetch_timezone_data()
+            html_content = html_content.replace(tz_placeholder, tz_data)
+            print(f"  [{symbol}] Timezone data injected ({len(tz_data)} chars).")
+
+    raw_size = len(html_content.encode('utf-8'))
+    html_content = minify_html(html_content)
+    minified_bytes = html_content.encode('utf-8')
+    compressed = gzip.compress(minified_bytes, compresslevel=9)
+
+    print(f"  [{symbol}] {raw_size} -> minified {len(minified_bytes)} "
+          f"-> gzip {len(compressed)} bytes "
+          f"({100*len(compressed)//raw_size}% of raw)")
+
+    _write_gz_header(output_file, symbol, input_file, compressed)
+
+
+def generate_header(*args, **kwargs):
+    print("Generating compressed HTML payload...")
+    minifier = "minify-html" if _HAVE_MINIFY_HTML else "fallback (regex)"
+    if not _HAVE_MINIFY_HTML:
+        print("  Note: minify-html package not installed; using regex fallback.")
+        print("        Run setup.sh for ~3 KB more savings per file.")
     else:
-        print("  Note: No timezone placeholder found in HTML; skipping TZ embedding.")
+        print(f"  Minifier: {minifier}")
 
-    html_bytes = html_content.encode('utf-8')
-    compressed_content = gzip.compress(html_bytes)
+    # AP-mode captive-portal setup wizard. Needs TZ data injected at build time.
+    _process_html(
+        input_file="src/web/setup.html",
+        output_file="include/setup_html_gz.h",
+        symbol="setup_html_gz",
+        inject_tz=True,
+    )
 
-    print(f"  HTML: {len(html_bytes)} bytes -> gzip: {len(compressed_content)} bytes ({100*len(compressed_content)//len(html_bytes)}%)")
+    # Runtime dashboard. Plain HTML/CSS/JS, no build-time data injection.
+    _process_html(
+        input_file="src/web/web_ui.html",
+        output_file="include/web_ui_gz.h",
+        symbol="web_ui_gz",
+        inject_tz=False,
+    )
 
-    os.makedirs(os.path.dirname(output_file), exist_ok=True)
-    with open(output_file, 'w') as f:
-        f.write("#pragma once\n\n")
-        f.write(f"// Generated from {input_file}\n")
-        f.write("const uint8_t setup_html_gz[] = {\n")
-
-        hex_array = [f"0x{b:02x}" for b in compressed_content]
-        for i in range(0, len(hex_array), 16):
-            f.write("    " + ", ".join(hex_array[i:i+16]) + ",\n")
-
-        f.write("};\n\n")
-        f.write(f"const size_t setup_html_gz_len = {len(compressed_content)};\n")
 
 generate_header()

--- a/src/CpapWebServer.cpp
+++ b/src/CpapWebServer.cpp
@@ -2,7 +2,7 @@
 #include "Logger.h"
 #include "UploadFSM.h"
 #include "version.h"
-#include "web_ui.h"
+#include "web_ui_gz.h"
 #include "WebStatus.h"
 #include "setup_html_gz.h"
 #include <time.h>
@@ -484,7 +484,8 @@ void CpapWebServer::handleRoot() {
     server->sendHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
     server->sendHeader("Pragma", "no-cache");
     server->sendHeader("Connection", "close");
-    server->send_P(200, "text/html; charset=utf-8", WEB_UI_HTML);
+    server->sendHeader("Content-Encoding", "gzip");
+    server->send_P(200, "text/html", (const char*)web_ui_gz, web_ui_gz_len);
 }
 
 // GET /trigger-upload - Force immediate upload
@@ -779,7 +780,8 @@ public:
 void CpapWebServer::handleLogs() {
     server->sendHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
     server->sendHeader("Connection", "close");
-    server->send_P(200, "text/html; charset=utf-8", WEB_UI_HTML);
+    server->sendHeader("Content-Encoding", "gzip");
+    server->send_P(200, "text/html", (const char*)web_ui_gz, web_ui_gz_len);
 }
 
 // GET /api/logs - Legacy alias for circular-buffer logs
@@ -899,13 +901,15 @@ void CpapWebServer::handleApiLogsStream() {
 void CpapWebServer::handleConfigPage() {
     server->sendHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
     server->sendHeader("Connection", "close");
-    server->send_P(200, "text/html; charset=utf-8", WEB_UI_HTML);
+    server->sendHeader("Content-Encoding", "gzip");
+    server->send_P(200, "text/html", (const char*)web_ui_gz, web_ui_gz_len);
 }
 // GET /status - serve SPA
 void CpapWebServer::handleStatusPage() {
     server->sendHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
     server->sendHeader("Connection", "close");
-    server->send_P(200, "text/html; charset=utf-8", WEB_UI_HTML);
+    server->sendHeader("Content-Encoding", "gzip");
+    server->send_P(200, "text/html", (const char*)web_ui_gz, web_ui_gz_len);
 }
 // GET /api/status - rebuild snapshot on demand then serve it.
 // Must NOT rely on the main-loop periodic rebuild: during blocking uploads
@@ -1785,7 +1789,8 @@ void CpapWebServer::handleSdActivity() {
 void CpapWebServer::handleMonitorPage() {
     server->sendHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
     server->sendHeader("Connection", "close");
-    server->send_P(200, "text/html; charset=utf-8", WEB_UI_HTML);
+    server->sendHeader("Content-Encoding", "gzip");
+    server->send_P(200, "text/html", (const char*)web_ui_gz, web_ui_gz_len);
 }
 
 // ============================================================================

--- a/src/web/web_ui.html
+++ b/src/web/web_ui.html
@@ -1,11 +1,4 @@
-#pragma once
-#include <pgmspace.h>
-
-// Auto-served from flash via server->send_P() — zero heap allocation.
-// All rendering is client-side JS. ESP32 only serves this once per page load,
-// then the browser polls /api/status (includes diagnostics), /api/logs, /api/config, /api/sd-activity.
-
-static const char WEB_UI_HTML[] PROGMEM = R"HTMLEOF(<!DOCTYPE html><html><head>
+<!DOCTYPE html><html><head>
 <title>CPAP Uploader</title><meta charset=utf-8>
 <meta name=viewport content="width=device-width,initial-scale=1">
 <style>
@@ -1337,4 +1330,4 @@ function handleOtaResult(d,sid){
    startStatusPoll();
  },150);
 </script>
-</body></html>)HTMLEOF";
+</body></html>


### PR DESCRIPTION
setup.html now passes through minify-html (CSS+JS aggressive) before
gzip. web_ui's runtime dashboard, previously embedded as a raw
PROGMEM R-string, is now a generated gzipped header on the same pipeline.
The build script handles both files via a shared _process_html() helper,
with a conservative regex fallback if the minify-html package is missing.

setup_html_gz: 103302 -> minified 77563 -> gzip 19869 (19% of raw)
web_ui_gz:      71886 -> minified 62634 -> gzip 18516 (25% of raw)