### PR TITLE
WIFI rework - post review cleanup

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -151,10 +151,6 @@ public:
     bool loadFromString(const String& rawConfig);
     void overrideUploadMode(const String& mode);
     
-    // Slot-0 accessors (back-compat with single-network callers).
-    const String& getWifiSSID() const;
-    const String& getWifiPassword() const;
-
     // Multi-slot accessors. idx in [0, getWifiNetworkCount()).
     int getWifiNetworkCount() const;
     const String& getWifiSSID(int idx) const;

--- a/include/NetworkHints.h
+++ b/include/NetworkHints.h
@@ -9,11 +9,15 @@
 // (apply BSSID + channel directly) and to remember PMF/802.11w workarounds.
 //
 // Storage: NVS namespace "wifi_hints", single blob "blob" containing
-// [uint16 version][uint16 count][record x count]. 48 bytes per record,
-// capped at MAX_HINTS = 8 records, ~388 bytes total.
+// [uint16 version][uint16 count][record x count]. 52 bytes per record,
+// capped at MAX_HINTS = 8 records, ~420 bytes total.
 //
 // last_used_secs is epoch seconds (time(nullptr)) Used later for LRU eviction
 // at cap and for stale-entry cleanup.
+//
+// pmf_set_secs is when pmf_disable last transitioned (or was last revalidated
+// after TTL expiry). WiFiManager re-tests PMF posture if older than PMF_TTL_SECS
+// to detect router upgrades that re-enable 802.11w.
 
 struct SavedNetworkHint {
     char     ssid[33];          // null-terminated, max 32 chars + null
@@ -21,13 +25,15 @@ struct SavedNetworkHint {
     uint8_t  channel;           // 1..14 for 2.4 GHz
     uint8_t  pmf_disable;       // 1 = router needs PMF disabled (reason 208)
     uint32_t last_used_secs;    // epoch seconds (time()) at last successful use
+    uint32_t pmf_set_secs;      // epoch seconds when pmf_disable was last set/revalidated
 };
-static_assert(sizeof(SavedNetworkHint) == 48, "SavedNetworkHint must pack to 48 bytes for stable on-disk layout");
+static_assert(sizeof(SavedNetworkHint) == 52, "SavedNetworkHint must pack to 52 bytes for stable on-disk layout");
 
 class NetworkHints {
 public:
     static constexpr int      MAX_HINTS = 8;
-    static constexpr uint16_t BLOB_VERSION = 1;
+    static constexpr uint16_t BLOB_VERSION = 2;
+    static constexpr uint32_t PMF_TTL_SECS = 30u * 24u * 3600u;  // 30 days
 
     NetworkHints();
 

--- a/include/web_ui.h
+++ b/include/web_ui.h
@@ -469,6 +469,7 @@ function badgeHtml(st){var s=st.toLowerCase(),c='bi';
   return '<span class="badge '+c+'">'+st+'</span>';
 }
 function set(id,html,inner){var el=document.getElementById(id);if(el){if(inner===false)el.innerHTML=html;else el.textContent=html;}}
+function escHtml(s){return String(s).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
 function seti(id,html){set(id,html,false);}
 
 var statusFailCount=0,rebootExpected=false,lastStatusOkMs=0;
@@ -597,7 +598,8 @@ function renderStatus(d){
   }
   if(d.wifi){
     var rc=sigClass(d.rssi),rl=sigLabel(d.rssi);
-    document.getElementById('d-wifi').innerHTML='<span class='+rc+'>'+rl+' ('+d.rssi+' dBm)</span>';
+    var pref=d.wifi_ssid?escHtml(d.wifi_ssid)+' &middot; ':'';
+    document.getElementById('d-wifi').innerHTML=pref+'<span class='+rc+'>'+rl+' ('+d.rssi+' dBm)</span>';
   }else{set('d-wifi','Disconnected');}
   set('d-ep',cfg.endpoint_type||d.endpoint_type||'—');
   set('d-up',fmtUp(d.uptime||0));

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -727,8 +727,6 @@ bool Config::loadFromSD(fs::FS &sd) {
     return isValid;
 }
 
-const String& Config::getWifiSSID() const { return wifiNetworks[0].ssid; }
-const String& Config::getWifiPassword() const { return wifiNetworks[0].password; }
 int Config::getWifiNetworkCount() const { return wifiNetworkCount; }
 const String& Config::getWifiSSID(int idx) const {
     static const String empty;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -607,9 +607,11 @@ bool Config::loadFromSD(fs::FS &sd) {
             credentialsInFlash = false;
         } else {
             // Check loaded credentials for censorship (per WiFi slot + endpoint + cloud)
+            bool wifiWasCensored[WIFI_MAX_NETWORKS] = {false};
             bool anyWifiCensored = false;
             for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
                 if (isCensored(wifiNetworks[i].password)) {
+                    wifiWasCensored[i] = true;
                     anyWifiCensored = true;
                     const char* nvsKey = prefsKeyForWifiSlot(i);
                     if (nvsKey) {
@@ -636,11 +638,11 @@ bool Config::loadFromSD(fs::FS &sd) {
             bool needsMigration = false;
             for (int i = 0; i < WIFI_MAX_NETWORKS; i++) {
                 const String& pw = wifiNetworks[i].password;
-                if (!pw.isEmpty() && !isCensored(pw)) { needsMigration = true; break; }
+                if (!pw.isEmpty() && !wifiWasCensored[i]) { needsMigration = true; break; }
             }
             if (!endpointPassword.isEmpty() && !endpointCensored) needsMigration = true;
             if (!cloudClientSecret.isEmpty() && !cloudSecretCensored) needsMigration = true;
-            
+
             if (needsMigration) {
                 LOG("New plain text credentials detected in mask mode - attempting migration");
                 if (migrateToSecureStorage(sd)) {

--- a/src/CpapWebServer.cpp
+++ b/src/CpapWebServer.cpp
@@ -933,9 +933,12 @@ void CpapWebServer::updateStatusSnapshot() {
     unsigned long inStateSec = (millis() - stateEnteredAt) / 1000;
     const char* st = getStateName(currentState);
     int rssi = 0; bool wifiConn = false;
+    char wifiSsid[33] = {0};
     if (wifiManager && wifiManager->isConnected()) {
         wifiConn = true;
         rssi = wifiManager->getSignalStrength();
+        String s = WiFi.SSID();
+        strncpy(wifiSsid, s.c_str(), sizeof(wifiSsid) - 1);
     }
     // Per-backend folder counts — both backends render their own row in the UI.
     //
@@ -1068,7 +1071,7 @@ void CpapWebServer::updateStatusSnapshot() {
         "{\"state\":\"%s\",\"in_state_sec\":%lu,\"uptime\":%lu"
         ",\"time\":\"%s\",\"time_synced\":%s"
         ",\"free_heap\":%u,\"max_alloc\":%u"
-        ",\"wifi\":%s,\"rssi\":%d"
+        ",\"wifi\":%s,\"rssi\":%d,\"wifi_ssid\":\"%s\""
         ",\"backends\":{"
             "\"cloud\":{\"enabled\":%s,\"done\":%d,\"total\":%d,\"pending\":%d,\"last_ts\":%lu"
                 ",\"live\":{\"active\":%s,\"folder\":\"%s\",\"up\":%d,\"total\":%d}}"
@@ -1088,7 +1091,7 @@ void CpapWebServer::updateStatusSnapshot() {
         st, inStateSec, upSec,
         timeBuf, timeSynced ? "true" : "false",
         (unsigned)ESP.getFreeHeap(), (unsigned)ESP.getMaxAllocHeap(),
-        wifiConn ? "true" : "false", rssi,
+        wifiConn ? "true" : "false", rssi, wifiSsid,
         cloudEnabled ? "true" : "false", cloudDone, cloudTotal, cloudPending,
             (unsigned long)cloudLastTs,
             cloudLiveActive ? "true" : "false", cloudLiveFolder, cloudLiveUp, cloudLiveTotal,
@@ -1132,7 +1135,7 @@ void CpapWebServer::initConfigSnapshot() {
         ",\"cloud_configured\":%s"
         ",\"brownout_detect_mode\":\"%s\""
         ",\"firmware\":\"%s\"}",
-        config->getWifiSSID().c_str(),
+        config->getWifiSSID(0).c_str(),
         config->getHostname().c_str(),
         config->getEndpointType().c_str(),
         config->getEndpointUser().c_str(),

--- a/src/NetworkHints.cpp
+++ b/src/NetworkHints.cpp
@@ -116,9 +116,11 @@ bool NetworkHints::upsert(const char* ssid, const uint8_t* bssid, uint8_t channe
     if (!ssid || ssid[0] == '\0' || !bssid) return false;
 
     uint32_t nowSecs = (uint32_t)time(nullptr);
+    uint8_t  newPmf  = pmf_disable ? 1 : 0;
 
     int idx = findIndex(ssid, bssid);
-    if (idx < 0) {
+    bool wasNew = (idx < 0);
+    if (wasNew) {
         if (_count >= MAX_HINTS) evictLRUSlot();
         idx = _count;
         _count++;
@@ -127,9 +129,17 @@ bool NetworkHints::upsert(const char* ssid, const uint8_t* bssid, uint8_t channe
         memcpy(_hints[idx].bssid, bssid, 6);
     }
 
+    // Refresh pmf_set_secs on fresh entry, transition in the pmf_disable bit,
+    // or revalidation after the TTL expired
+    bool refreshPmfTs = wasNew
+        || (_hints[idx].pmf_disable != newPmf)
+        || (nowSecs > 1700000000u  // sanity-check post-NTP
+            && nowSecs - _hints[idx].pmf_set_secs > PMF_TTL_SECS);
+
     _hints[idx].channel        = channel;
-    _hints[idx].pmf_disable    = pmf_disable ? 1 : 0;
+    _hints[idx].pmf_disable    = newPmf;
     _hints[idx].last_used_secs = nowSecs;
+    if (refreshPmfTs) _hints[idx].pmf_set_secs = nowSecs;
     return true;
 }
 

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -441,7 +441,11 @@ void WiFiManager::processScanResults() {
     LOGF("WiFi scan: %d known of %d visible", _candidateCount, n);
 
     if (_candidateCount == 0) {
-        // Hidden-SSID fallback
+        // Hidden-SSID fallback: scan with show_hidden=false won't see APs that
+        // suppress beacons / probe responses for unknown SSIDs. Build blind
+        // candidates from each configured slot in config order (no RSSI signal
+        // to rank by) so the radio's own probe-with-known-SSID can find them.
+        // Cached hints (if any) supply BSSID + channel to skip the second scan.
         LOG_WARN("WiFi scan: no configured networks visible - trying configured slots blind (hidden SSID?)");
         for (int slot = 0; slot < cfgCount && _candidateCount < MAX_CANDIDATES; slot++) {
             Candidate& c = _candidates[_candidateCount];
@@ -512,8 +516,17 @@ bool WiFiManager::startCurrentCandidate() {
     if (hasBssid) {
         const SavedNetworkHint* hint = networkHints.find(_pendingSsid.c_str(), c.bssid);
         if (hint && hint->pmf_disable) {
-            _pendingPmfDisable = true;
-            LOGF("WiFi: hint says PMF disabled for '%s'", _pendingSsid.c_str());
+            uint32_t now = (uint32_t)time(nullptr);
+            // Honor cache if clock is unsynced
+            bool fresh = (now <= 1700000000u) ||
+                         (now - hint->pmf_set_secs < NetworkHints::PMF_TTL_SECS);
+            if (fresh) {
+                _pendingPmfDisable = true;
+                LOGF("WiFi: hint says PMF disabled for '%s'", _pendingSsid.c_str());
+            } else {
+                LOGF("WiFi: PMF-disable hint for '%s' aged out, re-testing PMF on",
+                     _pendingSsid.c_str());
+            }
         }
     }
 

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -441,7 +441,36 @@ void WiFiManager::processScanResults() {
     LOGF("WiFi scan: %d known of %d visible", _candidateCount, n);
 
     if (_candidateCount == 0) {
-        terminateConnect(ConnectPhase::FAILED);
+        // Hidden-SSID fallback
+        LOG_WARN("WiFi scan: no configured networks visible - trying configured slots blind (hidden SSID?)");
+        for (int slot = 0; slot < cfgCount && _candidateCount < MAX_CANDIDATES; slot++) {
+            Candidate& c = _candidates[_candidateCount];
+            c.configSlot = (uint8_t)slot;
+            memset(c.bssid, 0, 6);
+            c.channel = 0;
+            c.rssi    = -127;
+            const String& ssid = _pendingConfig->getWifiSSID(slot);
+            const SavedNetworkHint* best = nullptr;
+            for (int hi = 0; hi < networkHints.count(); hi++) {
+                const SavedNetworkHint* h = networkHints.at(hi);
+                if (h && strcmp(h->ssid, ssid.c_str()) == 0) {
+                    if (!best || h->last_used_secs > best->last_used_secs) best = h;
+                }
+            }
+            if (best) {
+                memcpy(c.bssid, best->bssid, 6);
+                c.channel = best->channel;
+            }
+            _candidateCount++;
+        }
+        if (_candidateCount == 0) {
+            terminateConnect(ConnectPhase::FAILED);
+            return;
+        }
+        // No RSSI signal to sort by; try in config order.
+        _candidateIndex   = 0;
+        _candidateRetries = 0;
+        startCurrentCandidate();
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1823,7 +1823,7 @@ void loop() {
         if (intervalElapsed && !busBusy) {
             LOG_WARN("WiFi disconnected, attempting to reconnect...");
 
-            if (!config.valid() || config.getWifiNetworkCount().isEmpty()) {
+            if (!config.valid() || config.getWifiNetworkCount() == 0) {
                 LOG_ERROR("Cannot reconnect to WiFi: no networks configured");
                 lastWifiReconnectAttempt = currentTime;
                 return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -699,7 +699,7 @@ void setup() {
     if (g_debugMode) {
         LOG_WARN("DEBUG mode enabled — verbose pre-flight logs and heap stats active");
     }
-    LOG_DEBUGF("WiFi SSID: %s", config.getWifiSSID().c_str());
+    LOG_DEBUGF("WiFi SSID: %s", config.getWifiSSID(0).c_str());
     LOG_DEBUGF("Endpoint: %s", config.getEndpoint().c_str());
 
     // Configure LittleFS-backed syslog rotation for optional periodic persistence
@@ -1823,8 +1823,8 @@ void loop() {
         if (intervalElapsed && !busBusy) {
             LOG_WARN("WiFi disconnected, attempting to reconnect...");
 
-            if (!config.valid() || config.getWifiSSID().isEmpty()) {
-                LOG_ERROR("Cannot reconnect to WiFi: Invalid configuration");
+            if (!config.valid() || config.getWifiNetworkCount().isEmpty()) {
+                LOG_ERROR("Cannot reconnect to WiFi: no networks configured");
                 lastWifiReconnectAttempt = currentTime;
                 return;
             }

--- a/test/test_config/test_config.cpp
+++ b/test/test_config/test_config.cpp
@@ -58,8 +58,8 @@ void test_config_load_valid() {
     
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.valid());
-    TEST_ASSERT_EQUAL_STRING("TestNetwork", config.getWifiSSID().c_str());
-    TEST_ASSERT_EQUAL_STRING("TestPassword123", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("TestNetwork", config.getWifiSSID(0).c_str());
+    TEST_ASSERT_EQUAL_STRING("TestPassword123", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("DAILY", config.getSchedule().c_str());
     TEST_ASSERT_EQUAL_STRING("//192.168.1.100/share/uploads", config.getEndpoint().c_str());
     TEST_ASSERT_EQUAL_STRING("SMB", config.getEndpointType().c_str());
@@ -88,7 +88,7 @@ void test_config_load_with_defaults() {
     
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.valid());
-    TEST_ASSERT_EQUAL_STRING("MinimalNetwork", config.getWifiSSID().c_str());
+    TEST_ASSERT_EQUAL_STRING("MinimalNetwork", config.getWifiSSID(0).c_str());
     TEST_ASSERT_EQUAL_STRING("//server/share", config.getEndpoint().c_str());
     
     // Check default values
@@ -158,7 +158,7 @@ void test_config_load_invalid_format() {
     // Should still load valid parts
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.valid());
-    TEST_ASSERT_EQUAL_STRING("ValidSSID", config.getWifiSSID().c_str());
+    TEST_ASSERT_EQUAL_STRING("ValidSSID", config.getWifiSSID(0).c_str());
 }
 
 // Test loading empty config file
@@ -344,7 +344,7 @@ void test_config_plain_text_mode() {
     TEST_ASSERT_TRUE_MESSAGE(config.valid(), "Config should be valid");
     TEST_ASSERT_TRUE_MESSAGE(config.isStoringPlainText(), "Should be in plain text mode");
     TEST_ASSERT_FALSE_MESSAGE(config.areCredentialsInFlash(), "Credentials should not be in flash");
-    TEST_ASSERT_EQUAL_STRING("PlainTextPassword", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("PlainTextPassword", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("PlainEndpointPass", config.getEndpointPassword().c_str());
 }
 
@@ -367,7 +367,7 @@ void test_config_secure_mode_migration() {
     TEST_ASSERT_TRUE(config.areCredentialsInFlash());
     
     // Credentials should be loaded from Preferences
-    TEST_ASSERT_EQUAL_STRING("SecurePassword123", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("SecurePassword123", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("SecureEndpointPass", config.getEndpointPassword().c_str());
     
     // Config file should be censored
@@ -405,7 +405,7 @@ void test_config_secure_mode_already_censored() {
     TEST_ASSERT_TRUE(config2.areCredentialsInFlash());
     
     // Should load credentials from Preferences
-    TEST_ASSERT_EQUAL_STRING("OriginalPassword", config2.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("OriginalPassword", config2.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("OriginalEndpointPass", config2.getEndpointPassword().c_str());
 }
 
@@ -424,7 +424,7 @@ void test_config_credential_storage_various_lengths() {
     Config config1;
     bool loaded1 = config1.loadFromSD(mockSD);
     TEST_ASSERT_TRUE(loaded1);
-    TEST_ASSERT_EQUAL_STRING("abc", config1.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("abc", config1.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("123", config1.getEndpointPassword().c_str());
     
     // Test long password (64 characters)
@@ -441,7 +441,7 @@ void test_config_credential_storage_various_lengths() {
     Config config2;
     bool loaded2 = config2.loadFromSD(mockSD);
     TEST_ASSERT_TRUE(loaded2);
-    TEST_ASSERT_EQUAL_STRING(longPassword.c_str(), config2.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING(longPassword.c_str(), config2.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING(longPassword.c_str(), config2.getEndpointPassword().c_str());
     
     // Test password with special characters
@@ -459,7 +459,7 @@ void test_config_credential_storage_various_lengths() {
     Config config3;
     bool loaded3 = config3.loadFromSD(mockSD);
     TEST_ASSERT_TRUE(loaded3);
-    TEST_ASSERT_EQUAL_STRING(specialPass.c_str(), config3.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING(specialPass.c_str(), config3.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING(specialEndpoint.c_str(), config3.getEndpointPassword().c_str());
 }
 
@@ -502,7 +502,7 @@ void test_config_empty_credentials() {
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.valid());
     // Empty credentials should be handled gracefully
-    TEST_ASSERT_EQUAL_STRING("", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("", config.getEndpointPassword().c_str());
 }
 
@@ -543,7 +543,7 @@ void test_config_switch_plain_to_secure() {
     TEST_ASSERT_TRUE_MESSAGE(config2.areCredentialsInFlash(), "Credentials should be in flash");
     
     // Credentials should be migrated to Preferences
-    TEST_ASSERT_EQUAL_STRING("PlainPassword", config2.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("PlainPassword", config2.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("PlainEndpointPass", config2.getEndpointPassword().c_str());
 }
 
@@ -600,7 +600,7 @@ void test_config_multiple_instances() {
         Config config1;
         bool loaded1 = config1.loadFromSD(mockSD);
         TEST_ASSERT_TRUE(loaded1);
-        TEST_ASSERT_EQUAL_STRING("SharedPassword", config1.getWifiPassword().c_str());
+        TEST_ASSERT_EQUAL_STRING("SharedPassword", config1.getWifiPassword(0).c_str());
         // config1 destructor called here
     }
     
@@ -609,7 +609,7 @@ void test_config_multiple_instances() {
     Config config2;
     bool loaded2 = config2.loadFromSD(mockSD);
     TEST_ASSERT_TRUE(loaded2);
-    TEST_ASSERT_EQUAL_STRING("SharedPassword", config2.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("SharedPassword", config2.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("SharedEndpointPass", config2.getEndpointPassword().c_str());
 }
 
@@ -628,7 +628,7 @@ void test_config_wifi_only_secure() {
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.valid());
     TEST_ASSERT_TRUE(config.areCredentialsInFlash());
-    TEST_ASSERT_EQUAL_STRING("WiFiOnlyPassword", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("WiFiOnlyPassword", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("", config.getEndpointPassword().c_str());
 }
 
@@ -647,7 +647,7 @@ void test_config_endpoint_only_secure() {
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.valid());
     TEST_ASSERT_TRUE(config.areCredentialsInFlash());
-    TEST_ASSERT_EQUAL_STRING("", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("EndpointOnlyPassword", config.getEndpointPassword().c_str());
 }
 
@@ -690,7 +690,7 @@ void test_config_update_wifi_only() {
     TEST_ASSERT_TRUE_MESSAGE(config2.valid(), "Config should be valid");
     
     // Should use new WiFi password from config, stored endpoint password from flash
-    TEST_ASSERT_EQUAL_STRING("NewWiFiPassword123", config2.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("NewWiFiPassword123", config2.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("OriginalEndpointPass", config2.getEndpointPassword().c_str());
     TEST_ASSERT_TRUE_MESSAGE(config2.areCredentialsInFlash(), "Should have credentials in flash");
 }
@@ -730,7 +730,7 @@ void test_config_update_endpoint_only() {
     TEST_ASSERT_TRUE_MESSAGE(config2.valid(), "Config should be valid");
     
     // Should use stored WiFi password from flash, new endpoint password from config
-    TEST_ASSERT_EQUAL_STRING("OriginalWiFiPass", config2.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("OriginalWiFiPass", config2.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("NewEndpointPassword456", config2.getEndpointPassword().c_str());
     TEST_ASSERT_TRUE_MESSAGE(config2.areCredentialsInFlash(), "Should have credentials in flash");
 }
@@ -770,7 +770,7 @@ void test_config_update_both_credentials() {
     TEST_ASSERT_TRUE_MESSAGE(config2.valid(), "Config should be valid");
     
     // Should use both new passwords from config
-    TEST_ASSERT_EQUAL_STRING("NewWiFiPassword123", config2.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("NewWiFiPassword123", config2.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("NewEndpointPassword456", config2.getEndpointPassword().c_str());
     TEST_ASSERT_TRUE_MESSAGE(config2.areCredentialsInFlash(), "Should have credentials in flash after migration");
 }
@@ -800,7 +800,7 @@ void test_config_mixed_state_wifi_new() {
     TEST_ASSERT_TRUE_MESSAGE(config.valid(), "Config should be valid");
     
     // Should use new WiFi password from config, stored endpoint password from flash
-    TEST_ASSERT_EQUAL_STRING("NewWiFiPassword", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("NewWiFiPassword", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("StoredEndpointPass", config.getEndpointPassword().c_str());
     TEST_ASSERT_TRUE_MESSAGE(config.areCredentialsInFlash(), "Should have credentials in flash");
 }
@@ -830,7 +830,7 @@ void test_config_mixed_state_endpoint_new() {
     TEST_ASSERT_TRUE_MESSAGE(config.valid(), "Config should be valid");
     
     // Should use stored WiFi password from flash, new endpoint password from config
-    TEST_ASSERT_EQUAL_STRING("StoredWiFiPass", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("StoredWiFiPass", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("NewEndpointPassword", config.getEndpointPassword().c_str());
     TEST_ASSERT_TRUE_MESSAGE(config.areCredentialsInFlash(), "Should have credentials in flash");
 }
@@ -861,7 +861,7 @@ void test_config_mixed_state_both_new() {
     TEST_ASSERT_TRUE_MESSAGE(config.valid(), "Config should be valid");
     
     // Should use new passwords from config (prioritized over stored ones)
-    TEST_ASSERT_EQUAL_STRING("NewWiFiPassword", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("NewWiFiPassword", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("NewEndpointPassword", config.getEndpointPassword().c_str());
     TEST_ASSERT_TRUE_MESSAGE(config.areCredentialsInFlash(), "Should have credentials in flash");
 }

--- a/test/test_credential_migration/test_credential_migration.cpp
+++ b/test/test_credential_migration/test_credential_migration.cpp
@@ -43,7 +43,7 @@ void test_migration_plain_to_secure() {
     
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.areCredentialsInFlash());
-    TEST_ASSERT_EQUAL_STRING("MyWifiPass123", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("MyWifiPass123", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("MyEndpointPass456", config.getEndpointPassword().c_str());
     
     // Verify config.txt was censored
@@ -76,7 +76,7 @@ void test_migration_already_migrated() {
     
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.areCredentialsInFlash());
-    TEST_ASSERT_EQUAL_STRING("StoredWifiPass", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("StoredWifiPass", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("StoredEndpointPass", config.getEndpointPassword().c_str());
 }
 
@@ -97,7 +97,7 @@ void test_migration_plain_text_mode() {
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_FALSE(config.areCredentialsInFlash());
     TEST_ASSERT_TRUE(config.isStoringPlainText());
-    TEST_ASSERT_EQUAL_STRING("PlainWifiPass", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("PlainWifiPass", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("PlainEndpointPass", config.getEndpointPassword().c_str());
     
     // Verify config.txt was NOT censored
@@ -122,7 +122,7 @@ void test_migration_empty_credentials() {
     
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_FALSE(config.areCredentialsInFlash());
-    TEST_ASSERT_EQUAL_STRING("", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("", config.getEndpointPassword().c_str());
 }
 
@@ -150,7 +150,7 @@ void test_migration_persistence() {
         bool loaded = config2.loadFromSD(mockSD);
         TEST_ASSERT_TRUE(loaded);
         TEST_ASSERT_TRUE(config2.areCredentialsInFlash());
-        TEST_ASSERT_EQUAL_STRING("PersistentPass123", config2.getWifiPassword().c_str());
+        TEST_ASSERT_EQUAL_STRING("PersistentPass123", config2.getWifiPassword(0).c_str());
         TEST_ASSERT_EQUAL_STRING("PersistentEndpoint456", config2.getEndpointPassword().c_str());
     }
 }
@@ -176,7 +176,7 @@ void test_migration_mixed_state() {
     
     TEST_ASSERT_TRUE(loaded);
     TEST_ASSERT_TRUE(config.areCredentialsInFlash());
-    TEST_ASSERT_EQUAL_STRING("StoredWifiPass", config.getWifiPassword().c_str());
+    TEST_ASSERT_EQUAL_STRING("StoredWifiPass", config.getWifiPassword(0).c_str());
     TEST_ASSERT_EQUAL_STRING("PlainEndpointPass", config.getEndpointPassword().c_str());
 }
 


### PR DESCRIPTION
Some cleanup after reviewing the wifi rework changes.
Nothing major - notable bits:
- fix for redundant credentials migration on startup
- roaming works with hidden networks
- dashboard shows the currently connected SSID

the rest is minor cleanup and API tidying